### PR TITLE
Fix CI missing OLLAMA_URL for dual-judge mode

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -74,6 +74,7 @@ jobs:
         env:
           TESTLINK_URL: ${{ secrets.TESTLINK_URL }}
           TESTLINK_API_KEY: ${{ secrets.TESTLINK_API_KEY }}
+          OLLAMA_URL: ${{ secrets.OLLAMA_URL }}
         run: |
           cd cicd/tests
 

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ coverage/
 cicd/results/*
 !cicd/results/.gitignore
 cicd/tests/node_modules/
+cicd/tests/dist/


### PR DESCRIPTION
## Summary
- Add `OLLAMA_URL` secret to GitHub and pass it in `test-suite.yml` env block
- Add `cicd/tests/dist/` to `.gitignore` (stale build artifacts)

Fixes #43

## Test plan
- [ ] Trigger test-suite workflow with dual judge mode, verify OLLAMA_URL is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)