### PR TITLE
Add judge_mode/judge_model inputs to CI and Docker workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,20 @@ name: CI
 
 on:
   workflow_dispatch:
+    inputs:
+      judge_mode:
+        description: "Test judge mode"
+        required: false
+        default: "simple"
+        type: choice
+        options:
+          - "simple"
+          - "dual"
+      judge_model:
+        description: "LLM model for judging (if dual mode)"
+        required: false
+        default: "gemma3:12b-judge"
+        type: string
 
 jobs:
   build:
@@ -9,4 +23,6 @@ jobs:
     uses: ./.github/workflows/test-suite.yml
     with:
       suite: s1-build-deploy
-      judge_mode: simple
+      judge_mode: ${{ inputs.judge_mode }}
+      judge_model: ${{ inputs.judge_model }}
+    secrets: inherit

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,20 @@ name: Docker Publish
 
 on:
   workflow_dispatch:
+    inputs:
+      judge_mode:
+        description: "Test judge mode"
+        required: false
+        default: "simple"
+        type: choice
+        options:
+          - "simple"
+          - "dual"
+      judge_model:
+        description: "LLM model for judging (if dual mode)"
+        required: false
+        default: "gemma3:12b-judge"
+        type: string
 
 jobs:
   build-test:
@@ -9,7 +23,9 @@ jobs:
     uses: ./.github/workflows/test-suite.yml
     with:
       suite: s1-build-deploy
-      judge_mode: simple
+      judge_mode: ${{ inputs.judge_mode }}
+      judge_model: ${{ inputs.judge_model }}
+    secrets: inherit
 
   publish:
     name: Build & Push Docker Image

--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -25,6 +25,7 @@ jobs:
       suite: s1-build-deploy
       judge_mode: ${{ inputs.judge_mode }}
       judge_model: ${{ inputs.judge_model }}
+    secrets: inherit
 
   s2-test-case:
     name: "S2: Test Case Management"


### PR DESCRIPTION
## Summary
- Add `judge_mode` and `judge_model` dispatch inputs to `ci.yml` and `docker-publish.yml`
- Add `secrets: inherit` to both workflows so dual-judge mode has access to `OLLAMA_URL`
- Default remains `simple` for backwards compatibility

Fixes #45

## Test plan
- [ ] Trigger CI workflow with default (simple) — should work as before
- [ ] Trigger CI workflow with dual — should use Ollama judge

🤖 Generated with [Claude Code](https://claude.com/claude-code)