### PR TITLE
Add test_id input to test-suite workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ on:
         required: false
         default: "gemma3:12b-judge"
         type: string
+      test_id:
+        description: "Run a single test by ID (e.g., TC-S1-001)"
+        required: false
+        type: string
 
 jobs:
   build:
@@ -25,4 +29,5 @@ jobs:
       suite: s1-build-deploy
       judge_mode: ${{ inputs.judge_mode }}
       judge_model: ${{ inputs.judge_model }}
+      test_id: ${{ inputs.test_id }}
     secrets: inherit

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,10 @@ on:
         required: false
         default: "gemma3:12b-judge"
         type: string
+      test_id:
+        description: "Run a single test by ID (e.g., TC-S1-001)"
+        required: false
+        type: string
 
 jobs:
   build-test:
@@ -25,6 +29,7 @@ jobs:
       suite: s1-build-deploy
       judge_mode: ${{ inputs.judge_mode }}
       judge_model: ${{ inputs.judge_model }}
+      test_id: ${{ inputs.test_id }}
     secrets: inherit
 
   publish:

--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -16,6 +16,10 @@ on:
         required: false
         default: "gemma3:12b-judge"
         type: string
+      test_id:
+        description: "Run a single test by ID (e.g., TC-S1-001)"
+        required: false
+        type: string
 
 jobs:
   s1-build-deploy:
@@ -25,6 +29,7 @@ jobs:
       suite: s1-build-deploy
       judge_mode: ${{ inputs.judge_mode }}
       judge_model: ${{ inputs.judge_model }}
+      test_id: ${{ inputs.test_id }}
     secrets: inherit
 
   s2-test-case:
@@ -35,6 +40,7 @@ jobs:
       suite: s2-test-case
       judge_mode: ${{ inputs.judge_mode }}
       judge_model: ${{ inputs.judge_model }}
+      test_id: ${{ inputs.test_id }}
     secrets: inherit
 
   s3-test-suite:
@@ -45,6 +51,7 @@ jobs:
       suite: s3-test-suite
       judge_mode: ${{ inputs.judge_mode }}
       judge_model: ${{ inputs.judge_model }}
+      test_id: ${{ inputs.test_id }}
     secrets: inherit
 
   s4-test-plan:
@@ -55,6 +62,7 @@ jobs:
       suite: s4-test-plan
       judge_mode: ${{ inputs.judge_mode }}
       judge_model: ${{ inputs.judge_model }}
+      test_id: ${{ inputs.test_id }}
     secrets: inherit
 
   s5-build-mgmt:
@@ -65,6 +73,7 @@ jobs:
       suite: s5-build-mgmt
       judge_mode: ${{ inputs.judge_mode }}
       judge_model: ${{ inputs.judge_model }}
+      test_id: ${{ inputs.test_id }}
     secrets: inherit
 
   s7-requirements:
@@ -75,4 +84,5 @@ jobs:
       suite: s7-requirements
       judge_mode: ${{ inputs.judge_mode }}
       judge_model: ${{ inputs.judge_model }}
+      test_id: ${{ inputs.test_id }}
     secrets: inherit

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -29,6 +29,10 @@ on:
         required: false
         default: "gemma3:12b-judge"
         type: string
+      test_id:
+        description: "Run a single test by ID (e.g., TC-S1-001)"
+        required: false
+        type: string
   workflow_call:
     inputs:
       suite:
@@ -44,6 +48,10 @@ on:
         description: "LLM model for judging"
         required: false
         default: "gemma3:12b-judge"
+        type: string
+      test_id:
+        description: "Run a single test by ID"
+        required: false
         type: string
     outputs:
       result:
@@ -92,12 +100,19 @@ jobs:
             SUITE_FLAG="--suite ${{ inputs.suite }}"
           fi
 
+          # Build test ID flag
+          ID_FLAG=""
+          if [ -n "${{ inputs.test_id }}" ]; then
+            ID_FLAG="--id ${{ inputs.test_id }}"
+          fi
+
           echo "Suite: ${{ inputs.suite }}"
+          echo "Test ID: ${{ inputs.test_id || 'all' }}"
           echo "Judge mode: ${{ inputs.judge_mode || 'dual' }}"
           echo "Judge flags: $JUDGE_FLAGS"
 
           # Run tests with JSON output
-          npx tsx src/cli.ts run $SUITE_FLAG $JUDGE_FLAGS --format json > /tmp/test-results.json || true
+          npx tsx src/cli.ts run $SUITE_FLAG $ID_FLAG $JUDGE_FLAGS --format json > /tmp/test-results.json || true
 
           echo "--- JSON Results ---"
           cat /tmp/test-results.json


### PR DESCRIPTION
## Summary
- Add optional `test_id` input to `test-suite.yml` (both `workflow_dispatch` and `workflow_call`)
- Pass `--id` flag to CLI when `test_id` is provided
- Allows running a single test case (e.g., `TC-S1-001`) from GitHub Actions

Fixes #47

## Test plan
- [ ] Trigger test-suite with suite=s1-build-deploy, test_id=TC-S1-001
- [ ] Trigger test-suite with suite=s1-build-deploy, no test_id (runs all S1 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)