### PR TITLE
Redesign CLAUDE.md and extract code-review skill

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: code-review
+description: |
+  Code review guidelines for testlink-mcp server. Use when writing,
+  reviewing, or refactoring TypeScript source code in src/ or workflow
+  files in .github/workflows/. Covers design patterns, consistency
+  rules, and error handling.
+---
+
+# Code Review: testlink-mcp
+
+## Core Rule
+
+Fail fast. Keep simple. Every line of code is a liability.
+
+## Consistency Rules (CRITICAL)
+
+These rules prevent the most common implementation mistakes:
+
+1. **Propagate interface changes** — When adding a parameter, option, or input to any interface (function signature, workflow input, API endpoint, config schema), update ALL callers and consumers. Search the entire codebase for call sites before marking the task done.
+2. **Treat similar files as a group** — Workflow files, config files, test files, and route handlers that follow the same pattern are a group. A change to one member must be evaluated against all members. Default to applying the change to all.
+3. **Single source of truth** — Every configurable value should be defined once and passed through, never hardcoded at call sites. If a reusable workflow accepts an input, all calling workflows must expose and pass that input.
+4. **Contract-first changes** — When modifying a shared interface (reusable workflow, library function, API), first update the interface, then update every consumer in the same PR. Never leave consumers out of sync.
+
+## Design Principles
+
+1. **Fail Fast** — Throw immediately on invalid state. No null/undefined returns for errors.
+2. **Minimal Validation** — Trust TypeScript types. Validate only at system boundaries.
+3. **No Defensive Programming** — Don't check impossible states. Don't add safety nets for theoretical edge cases.
+4. **Simple Error Handling** — One error boundary per operation. Let errors bubble up.
+5. **Direct Code Flow** — Early returns over nesting. No intermediate variables for single-use values.
+6. **Minimal Abstractions** — No wrappers around simple operations. Functions over classes when stateless.
+7. **Trust the Platform** — Let TypeScript handle type errors. Let the API validate its own data.
+
+## Established Patterns
+
+1. **Tool Definition** — All tools in single array. snake_case names. Object-type input schema. Required fields explicit.
+2. **API Methods** — Single class (TestLinkAPI). All async. Return raw API response. Single error handler (handleAPICall).
+3. **Validation** — Validate only at tool entry point. Single validation per parameter. Throw immediately. Reuse validators (DRY).
+4. **Error Handling** — Throw Error objects with simple messages (<10 words). Map API error codes. No recovery attempts.
+5. **Naming** — Tools: `verb_noun`. Functions: `camelCase`. Classes: `PascalCase`. Constants: `UPPER_SNAKE_CASE`.
+6. **Routing** — Single switch for all tools. Direct API calls in each case. Consistent response format.
+7. **Workflow inputs** — All reusable workflow inputs must be exposed by every calling workflow. No hardcoded values for configurable options.
+
+## Constraints
+
+- Functions: max 20 lines, max 3 parameters
+- Error messages: max 10 words, include relevant ID/value, state what failed
+- No console.log/console.error
+- No health check endpoints
+- No retry logic without specific requirement
+- No new abstraction layers
+- No new validation helper unless shared by 3+ tools
+
+## Pre-Commit Checklist
+
+Before marking implementation done, verify:
+
+- [ ] All callers of modified interfaces updated
+- [ ] All files in the same pattern group reviewed
+- [ ] No hardcoded values where a pass-through input exists
+- [ ] New options propagated through the full call chain

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,194 +1,22 @@
-# TestLink MCP Server - Code Review Guidelines
+# TestLink MCP Server
 
-## Core Philosophy: Fail Fast, Keep Simple
+## Project
 
-### Design Principles
+MCP server connecting Claude to TestLink test management. TypeScript, Node.js 20+, Docker.
 
-1. **Fail Fast**
-   - Throw errors immediately when something is wrong
-   - Don't return null or undefined to indicate failure
-   - Let the process crash and restart cleanly
-   - No silent failures or fallback values
+## Code Style
 
-2. **Minimal Validation**
-   - Trust TypeScript type system
-   - Validate only at system boundaries (user input, API responses)
-   - Don't validate what's already been validated
-   - Skip format checking if the API will check it anyway
+Fail fast, keep simple. See `.claude/skills/code-review/` for full guidelines.
 
-3. **No Defensive Programming**
-   - Don't check for impossible states
-   - Don't add safety nets for theoretical edge cases
-   - Trust function contracts and types
-   - Assume happy path unless proven otherwise
+## Agent Behavior Rules
 
-4. **No Health Checks**
-   - Don't ping services to check if they're alive
-   - Don't pre-validate connections
-   - Just try the operation and handle actual failures
-   - Let connection errors surface naturally
+1. **Apply changes uniformly** — When modifying one file in a group (e.g., workflow files, config files), apply the same change to ALL files in that group. Do not skip files based on reasoning about whether they "need" it.
+2. **Do not assume future state** — Never justify skipping work by predicting what will or won't happen (e.g., "IDs will always be unique"). Apply the change, then flag concerns as separate issues.
+3. **Do not narrow scope without asking** — If the user says "fix all workflows", fix ALL workflows. Do not decide some don't need fixing.
+4. **Flag concerns separately** — If you spot a potential issue during implementation, finish the implementation first, then raise the concern as a separate issue or comment. Do not let concerns block or reduce the current work.
+5. **Consistency over optimization** — When in doubt, prefer consistent treatment across similar files over "smart" selective changes.
 
-5. **Simple Error Handling**
-   - One error boundary per request/operation
-   - Don't catch errors just to log them
-   - Don't wrap every function in try-catch
-   - Let errors bubble up to the appropriate handler
-
-6. **Direct Code Flow**
-   - Early returns over nested conditions
-   - Throw immediately on invalid state
-   - No intermediate variables for single-use values
-   - Linear execution path whenever possible
-
-7. **Minimal Abstractions**
-   - No wrappers around simple operations
-   - No factory patterns for single implementations
-   - No service layers that just forward calls
-   - Functions over classes when stateless
-
-8. **Trust the Platform**
-   - Let JavaScript/TypeScript handle type errors
-   - Let the API validate its own data
-   - Let Docker handle process restarts
-   - Let the MCP protocol handle transport errors
-
-## Code Review Checklist
-
-### MUST Have
-- [ ] Errors thrown immediately on invalid state
-- [ ] No null/undefined returns for error cases
-- [ ] Functions under 20 lines
-- [ ] Single responsibility per function
-- [ ] Clear error messages (under 10 words)
-- [ ] No console.log or console.error statements
-- [ ] Direct returns without unnecessary variables
-
-### MUST NOT Have
-- [ ] Health check endpoints or functions
-- [ ] Defensive null/undefined checks throughout code
-- [ ] Try-catch blocks around every operation
-- [ ] Validation of already-validated data
-- [ ] Multiple validation checks for same condition
-- [ ] Abstract base classes with single implementation
-- [ ] Success logging or debug statements
-- [ ] Configuration validation beyond presence check
-- [ ] Retry logic without specific requirement
-
-### Review Questions
-1. Can this validation be removed without breaking functionality?
-2. Will TypeScript catch this error at compile time?
-3. Is this abstraction used more than once?
-4. Can this error handling be moved to a higher level?
-5. Does this check protect against an actual observed failure?
-6. Can we let this operation fail naturally instead of checking first?
-7. Is this complexity justified by actual requirements?
-
-## Implementation Standards
-
-### Function Design
-- Maximum 20 lines per function
-- Maximum 3 parameters per function
-- Single return statement when possible
-- No nested callbacks or promises
-
-### Error Messages
-- Maximum 10 words
-- Include relevant ID or value
-- State what failed, not why
-- No stack traces in messages
-
-### API Interactions
-- Direct calls without wrappers
-- Let API errors surface as-is
-- No response transformation unless required
-- Trust API validation and error messages
-
-### Testing Approach
-- Test happy path thoroughly
-- Test actual observed error cases
-- Skip theoretical edge cases
-- No tests for impossible states
-
-## Design Pattern Consistency
-
-### Established Patterns
-
-1. **Tool Definition Pattern**
-   - All tools defined in single array
-   - Consistent naming: snake_case for tool names
-   - Input schema always uses object type
-   - Required fields explicitly listed
-
-2. **API Method Pattern**
-   - Single API class (TestLinkAPI)
-   - All API methods are async
-   - Return raw API response (no transformation)
-   - Single error handler wrapper (handleAPICall)
-
-3. **Validation Pattern**
-   - Validate only at tool entry point
-   - Single validation per parameter type
-   - Throw immediately on invalid input
-   - Reuse validation functions (DRY)
-
-4. **Error Handling Pattern**
-   - Throw Error objects with simple messages
-   - Map API error codes to user-friendly messages
-   - No error recovery attempts
-   - Let MCP protocol handle transport errors
-
-5. **Naming Conventions**
-   - Tools: verb_noun format (read_test_case, create_test_suite)
-   - Functions: camelCase (validateTestCaseId, parseTestCaseId)
-   - Classes: PascalCase (TestLinkAPI)
-   - Constants: UPPER_SNAKE_CASE (TESTLINK_URL, TESTLINK_API_KEY)
-
-6. **Switch Case Pattern**
-   - Single switch for all tool routing
-   - Direct API method calls in each case
-   - Consistent response format
-   - Single error handler for all tools
-
-### Consistency Checklist
-
-- [ ] New tools follow verb_noun naming pattern
-- [ ] API methods return raw responses without transformation
-- [ ] Validation happens only once per parameter
-- [ ] Error messages under 10 words
-- [ ] No new abstraction layers introduced
-- [ ] Switch case added for new tool
-- [ ] Tool schema matches existing patterns
-- [ ] No new validation helper unless shared by 3+ tools
-
-## Anti-Patterns to Avoid
-
-1. **Defensive Validation Chains**: Multiple checks for related conditions
-2. **Null Propagation**: Returning null through multiple layers
-3. **Silent Failures**: Catching errors without re-throwing
-4. **Preemptive Checks**: Validating before attempting operation
-5. **Over-Engineering**: Creating abstractions for future possibilities
-6. **Logging Everything**: Debug statements in production code
-7. **Configuration Validation**: Checking configuration format/structure
-8. **Wrapper Services**: Service classes that only forward calls
-
-## Decision Framework
-
-When reviewing code, ask:
-- **Is it simple?** Can a junior developer understand it?
-- **Does it fail fast?** Will errors surface immediately?
-- **Is it necessary?** Does it solve an actual problem?
-- **Is it direct?** Is this the shortest path to the solution?
-
-## Metrics for Success
-
-- Average function length: <10 lines
-- Try-catch blocks: <5 per file
-- Validation functions: <10% of codebase
-- Abstraction layers: Maximum 2
-- Error handling code: <15% of total
-- Time to error: <100ms from invalid input
-
-## Dev Workflow: Agent Lifecycle
+## Dev Workflow
 
 ### Commands
 
@@ -209,109 +37,42 @@ When reviewing code, ask:
 
 ```
 User Request
+  ├─► PLAN → TRACK → DEFINE → IMPLEMENT → TEST → PR → MERGE → NEXT
   │
-  ├─► PLAN: Enter plan mode, design solution
-  │   Trigger: User asks for a feature, fix, or change
-  │   Output: Plan with acceptance criteria, user approves
-  │
-  ├─► TRACK: /gh-init + /gh-track (once per task)
-  │   Trigger: User approves the plan
-  │   Output: Milestone, user story issue, task issues with checklists
-  │
-  ├─► DEFINE: /tl-define <issue#>
-  │   Trigger: Issue tracked, involves testable behavior
-  │   Output: Test cases created in TestLink, IDs posted to issue
-  │   Rule: TestLink is the single source of truth for test design
-  │   Rule: YAML test files reference testlink_id during implementation
-  │
-  ├─► IMPLEMENT: /gh-implement <issue#>
-  │   Trigger: TestLink test cases defined (or issue has no testable behavior)
-  │   Output: Branch with commits, checkboxes updated in real-time
-  │   Rule: Commit messages include "refs #N"
-  │   Rule: Check off each task checkbox as it completes
-  │
-  ├─► TEST: /gh-test
-  │   Trigger: All task checkboxes checked for the issue
-  │   Output: Build + test results reported to issue
-  │   Rule: Do NOT proceed if build or tests fail
-  │
-  ├─► PR: /gh-pr
-  │   Trigger: Tests pass
-  │   Output: PR with "Fixes #N", files changed, test results
-  │
-  ├─► MERGE: /gh-merge
-  │   Trigger: User says merge (NEVER auto-merge)
-  │   Output: Squash merge to main, branch deleted
-  │
-  └─► NEXT: /gh-status → pick next open issue or close milestone
+  Rules:
+  - MERGE requires explicit user approval (NEVER auto-merge)
+  - Implement issues sequentially (one branch per issue)
+  - Commit messages include "refs #N"
+  - Check off task checkboxes as each completes
+  - PR body includes "Fixes #N" to auto-close issue
 ```
 
-### Agent Auto-Trigger Rules
+### Auto-Trigger Rules
 
-The agent advances automatically through the lifecycle EXCEPT before merge:
+The agent advances automatically EXCEPT before merge:
 
-1. After user approves plan → run `/gh-init` then `/gh-track` for each task
-2. After tracking complete, if issue involves testable behavior → run `/tl-define`
-3. After test cases defined (or no testable behavior) → start `/gh-implement` on first open issue
-4. After all checkboxes checked → run `/gh-test`
-5. After tests pass → run `/gh-pr`
-6. After PR created → **STOP and wait for user** (merge is a human decision)
-7. After user says merge → run `/gh-merge`
-8. After merge, if more issues open → `/gh-implement` next issue
-9. After merge, if no issues open → close milestone, report done
-10. Implement issues sequentially (one branch per issue)
+1. After user approves plan → `/gh-init` then `/gh-track`
+2. After tracking, if testable → `/tl-define`
+3. After test cases defined → `/gh-implement` first open issue
+4. After all checkboxes checked → `/gh-test`
+5. After tests pass → `/gh-pr`
+6. After PR created → **STOP** (merge is human decision)
+7. After user says merge → `/gh-merge`
+8. After merge → next issue or close milestone
+
+### Conventions
+
+- **Branches**: `<type>/<short-desc>-#<issue>` (types: feat, fix, refactor, docs, test)
+- **Issue titles**: `[<type>] <action description>`
+- **Labels**: feat, fix, refactor, docs, test + priority:high/med/low
 
 ### Traceability
 
 ```
-User Story (milestone + story issue with acceptance criteria)
-  └─► Task Issue #N (checklist in body)
-       ├─► TestLink: test cases created via /tl-define, IDs posted to issue
-       ├─► Branch: type/desc-#N
-       ├─► Commits: "refs #N"
-       ├─► Files: listed in issue "Files" section (updated during implementation)
-       ├─► YAML tests: testlink_id field links to TestLink cases
-       ├─► Executions: /gh-test reports results back to TestLink
-       └─► PR: "Fixes #N" → auto-closes issue on merge
+Milestone (user story)
+  └─► Issue #N (task checklist)
+       ├─► TestLink test cases (via /tl-define)
+       ├─► Branch + commits (refs #N)
+       ├─► PR (Fixes #N → auto-close)
+       └─► Test results (reported to issue + TestLink)
 ```
-
-The agent maintains this chain by:
-- Updating issue "Files" section when files are created/modified
-- Checking off task checkboxes as each task completes
-- Including `Fixes #N` in PR body to auto-close issue
-- Including files changed list in PR body
-
-### Checkpoint: Updating Issue Checkboxes
-
-During `/gh-implement`, after completing each task:
-
-```bash
-# Fetch current body (always fetch latest to avoid conflicts)
-BODY=$(gh issue view <number> --json body -q .body)
-# Replace "- [ ] Task" with "- [x] Task" for the completed task
-# Update issue
-gh issue edit <number> --body "$BODY"
-```
-
-### Branch Naming
-
-```
-<type>/<short-desc>-#<issue>
-```
-
-Types: `feat`, `fix`, `refactor`, `docs`, `test`
-
-### Issue Title Format
-
-```
-[<type>] <action description>
-```
-
-### Labels
-
-- `feat`, `fix`, `refactor`, `docs`, `test` — task type
-- `priority:high`, `priority:med`, `priority:low` — urgency
-
----
-
-*Remember: Every line of code is a liability. The best code is no code.*


### PR DESCRIPTION
## Summary
- Slim CLAUDE.md from 317 lines to ~75 lines
- Extract code review guidelines to `.claude/skills/code-review/SKILL.md` (loaded on-demand)
- Add agent behavior rules to CLAUDE.md preventing reasoning shortcuts
- Add consistency rules to code-review skill (propagate interface changes, treat similar files as a group, single source of truth, contract-first changes)

Fixes #49

## Test plan
- [ ] Verify code-review skill appears in available skills list
- [ ] Verify agent applies changes uniformly in next implementation task

🤖 Generated with [Claude Code](https://claude.com/claude-code)