### PR TITLE
[fix] Disable LLM judge by default, fix simple judge isError false positive

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -19,7 +19,7 @@ on:
       judge_mode:
         description: "Test judge mode"
         required: false
-        default: "dual"
+        default: "simple"
         type: choice
         options:
           - "simple"
@@ -42,7 +42,7 @@ on:
       judge_mode:
         description: "Test judge mode (simple, dual)"
         required: false
-        default: "dual"
+        default: "simple"
         type: string
       judge_model:
         description: "LLM model for judging"
@@ -86,12 +86,10 @@ jobs:
         run: |
           cd cicd/tests
 
-          # Build judge flags based on input
+          # Build judge flags based on input (simple judge is the default; LLM is opt-in)
           JUDGE_FLAGS=""
-          if [ "${{ inputs.judge_mode }}" = "simple" ]; then
-            JUDGE_FLAGS="--no-llm"
-          else
-            JUDGE_FLAGS="--judge-model ${{ inputs.judge_model || 'llama3:8b' }}"
+          if [ "${{ inputs.judge_mode }}" = "dual" ]; then
+            JUDGE_FLAGS="--llm --judge-model ${{ inputs.judge_model || 'llama3:8b' }}"
           fi
 
           # Build suite flag

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -33,7 +33,7 @@ program
   .option('-s, --suite <suite>', 'Run only tests from this suite')
   .option('-i, --id <id>', 'Run only the test with this ID')
   .option('--dry-run', 'Show what would run without executing', false)
-  .option('--no-llm', 'Skip LLM judging (simple judge only)')
+  .option('--llm', 'Enable LLM judging (simple judge only by default)', false)
   .option('--judge-url <url>', 'Ollama URL for LLM judge', CONFIG.llm.defaultUrl)
   .option('--judge-model <model>', 'Model to use for LLM judging', CONFIG.llm.defaultModel)
   .option('-o, --output-dir <dir>', 'Output directory for results')

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -64,4 +64,5 @@ export const ERROR_PATTERNS: RegExp[] = [
 export const ERROR_EXCLUSIONS: RegExp[] = [
   /error.*handled/i,
   /expected.*error/i,
+  /isError/,
 ];

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -242,7 +242,7 @@ export interface RunConfig {
  */
 export const DEFAULT_CONFIG: Partial<RunConfig> = {
   dryRun: false,
-  noLlm: false,
+  noLlm: true,
   judgeUrl: 'http://localhost:11434',
   judgeModel: 'llama3:8b',
   outputFormat: 'console',


### PR DESCRIPTION
Fixes #41

## Summary
- **Fix #41**: add `/isError/` to `ERROR_EXCLUSIONS` so the simple judge's `/\berror\b/i` pattern no longer matches the MCP `isError` field name (unblocks TC-S3-003).
- **Disable LLM judge by default** (code kept, opt-in only):
  - `cli.ts`: `--no-llm` (opt-out) → `--llm` (opt-in, default off)
  - `types.ts`: `DEFAULT_CONFIG.noLlm` `false` → `true`
  - `test-suite.yml`: `judge_mode` default `dual` → `simple`; dual mode now passes `--llm --judge-model`. `ci.yml`/`test-pipeline.yml` already defaulted `simple`.

With the LLM judge off by default the simple judge becomes the sole arbiter, which is why the `isError` false positive had to be fixed alongside.

## Verification
- `tsc --noEmit` passes
- Default run reports `LLM Judge: disabled`; `--llm` re-enables it

## Note
`ERROR_EXCLUSIONS` is matched against the combined log blob, so a test containing `isError` also suppresses a genuine `error` match in that same test. This is the requested fix; per-pattern exclusions would be a more precise follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)