### PR TITLE
[fix] Run Docker publish on the self-hosted runner (no secrets)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,7 +55,9 @@ jobs:
 
       - name: Build and push (uses the runner's existing Docker login)
         run: |
-          docker build --label org.opencontainers.image.revision=${{ github.sha }} -t testlink-mcp:build .
+          # --no-cache --pull: release builds must come from current source and a
+          # fresh base image, never reusing layers cached on the persistent runner.
+          docker build --no-cache --pull --label org.opencontainers.image.revision=${{ github.sha }} -t testlink-mcp:build .
           echo "${{ steps.meta.outputs.tags }}" | while read -r tag; do
             [ -z "$tag" ] && continue
             echo "Pushing $tag"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,9 @@ jobs:
   publish:
     name: Build & Push Docker Image
     needs: build-test
-    runs-on: ubuntu-latest
+    # Runs on the self-hosted runner (asus-rock), which is already
+    # `docker login`-ed to Docker Hub — so no login step or secrets are needed.
+    runs-on: self-hosted
 
     steps:
       - name: Checkout
@@ -51,18 +53,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: |
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
+      - name: Build and push (uses the runner's existing Docker login)
+        run: |
+          docker build --label org.opencontainers.image.revision=${{ github.sha }} -t testlink-mcp:build .
+          echo "${{ steps.meta.outputs.tags }}" | while read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "Pushing $tag"
+            docker tag testlink-mcp:build "$tag"
+            docker push "$tag"
+          done


### PR DESCRIPTION
The Docker publish failed because `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets aren't set. Since the self-hosted runner (`asus-rock`) is already `docker login`-ed to Docker Hub, run the publish job there and use its existing credentials instead.

## Changes (`publish` job only)
- `runs-on: ubuntu-latest` → **`self-hosted`** (same runner the s1 tests already use).
- Removed `docker/login-action` (no secrets needed — machine is logged in).
- Replaced `docker/build-push-action` with a plain `docker build` + `docker tag`/`docker push` loop over the `metadata-action` tags (`1.3.0`, `1.3`, `latest`).

## Requirement
The runner process must run as the user that did `docker login` on `asus-rock` (so it can read `~/.docker/config.json`). The s1 job already runs `docker build` on this runner, so Docker access is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)