### PR TITLE
Import dev-workflow + testlink slash commands and syncing-testlink skill

### DIFF
--- a/.claude/commands/dev-workflow/dw-create-pr.md
+++ b/.claude/commands/dev-workflow/dw-create-pr.md
@@ -1,0 +1,97 @@
+# Create a Pull Request
+
+```
+Push branch and open a pull request with issue linkage.
+
+Issue number: {{input}}
+
+## PURPOSE
+
+Creates a pull request for the current branch, linking it to the GitHub Issue
+via "Fixes #N" for auto-closure. Updates issue labels to reflect PR status.
+
+---
+
+## WORKFLOW
+
+    /dw-create-pr 27
+        │
+        ├─► Step 1: Verify Readiness
+        │   - Confirm you're on the correct branch (issue-<N>-<slug>)
+        │   - Run: git status — check for uncommitted changes
+        │   - Review the branch's commits against the repo's default branch —
+        │     derive it, don't hardcode `main` (gh repo view --json
+        │     defaultBranchRef -q .defaultBranchRef.name):
+        │     git log --oneline <default>..HEAD
+        │   - If no argument given, infer issue number from branch name
+        │   - Run: gh issue view <N> — check if title contains [STORY-XXX]
+        │
+        ├─► Step 2: Push Branch
+        │   - Run: git push -u origin $(git branch --show-current)
+        │
+        ├─► Step 3: Create PR
+        │   - Title: short, imperative, under 70 characters
+        │   - Body must include "Fixes #N" or "Closes #N"
+        │   - Use this template:
+        │
+        │       gh pr create --title "<title>" --body "$(cat <<'EOF'
+        │       ## Summary
+        │       <1-3 bullet points>
+        │
+        │       Fixes #<issue-number>
+        │       (if linked to story: "Part of STORY-XXX")
+        │
+        │       ## Test plan
+        │       - [ ] ...
+        │
+        │       Generated with [Claude Code](https://claude.com/claude-code)
+        │       EOF
+        │       )"
+        │
+        ├─► Step 4: Update Issue Labels
+        │   - Run: gh issue edit <N> --remove-label "status:in-progress" \
+        │          --add-label "status:needs-review"
+        │   - Comment on issue:
+        │     gh issue comment <N> --body "PR #<PR> created. Summary: <what changed>"
+        │
+        ├─► Step 5: Update Story File (if linked)
+        │   - If the issue title contains [STORY-XXX]:
+        │     update docs/stories/STORY-XXX.md status to reflect PR is open
+        │   - Skip silently if no story link or docs/stories/ doesn't exist
+        │
+        └─► Step 6: Report
+            - Show the PR URL to the user
+            - Stop here — don't auto-advance. The PR now waits for a HUMAN to
+              review and test it. Merge with /dw-merge <PR> only once a human is
+              satisfied. (The change's substance was already gated locally by
+              /dw-review-implement before the PR.)
+
+---
+
+## EXAMPLE
+
+    /dw-create-pr 27
+
+**Agent verifies, pushes, creates PR:**
+
+    $ git status
+    $ git log --oneline <default-branch>..HEAD
+    $ git push -u origin issue-27-release-notes
+    $ gh pr create --title "Add release notes generator command" --body "..."
+    $ gh issue edit 27 --remove-label "status:in-progress" --add-label "status:needs-review"
+    $ gh issue comment 27 --body "PR #30 created."
+
+**Output:**
+
+    PR #30 created: https://github.com/owner/repo/pull/30
+    A human reviews + tests it; merge with /dw-merge 30 when satisfied.
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for PR and issue operations
+- `Fixes #N` in PR body auto-closes the issue when PR is merged
+- Copy relevant labels from the issue to the PR if needed
+- If branch is already pushed, the push step is a no-op
+```

--- a/.claude/commands/dev-workflow/dw-implement.md
+++ b/.claude/commands/dev-workflow/dw-implement.md
@@ -1,0 +1,123 @@
+# Implement a GitHub Issue
+
+```
+Start work on a GitHub Issue — create branch, implement, and track progress.
+
+Issue number: {{input}}
+
+## PURPOSE
+
+Picks up a GitHub Issue and drives it through implementation. Creates a feature
+branch, tracks status via labels and comments, handles failures transparently,
+and prepares for PR creation when done.
+
+---
+
+## WORKFLOW
+
+    /dw-implement 27
+        │
+        ├─► Step 1: Understand the Issue
+        │   - Run: gh issue view <N>
+        │   - Read acceptance criteria, technical notes, dependencies
+        │   - Check labels — type and priority should already be set
+        │   - Check for linked/blocking issues
+        │   - If the issue body links a plan ("Part of #<plan>"), read that plan
+        │     issue — its Approach is the agreed checkpoint to build from, so a fresh
+        │     session resumes without re-deriving it: gh issue view <plan>
+        │   - If issue title contains [STORY-XXX], read docs/stories/STORY-XXX.md
+        │     for full context (the user story and the need it serves)
+        │   - If anything is unclear, ask the user before starting
+        │
+        ├─► Step 2: Create Branch
+        │   - Branch name: issue-<N>-<short-slug>
+        │     Example: issue-27-release-notes
+        │   - Branch from the repo's default branch — derive it, don't hardcode
+        │     `main` (e.g. gh repo view --json defaultBranchRef -q
+        │     .defaultBranchRef.name); check it out and pull, then:
+        │     git checkout -b issue-<N>-<slug>
+        │   - Comment on issue:
+        │     gh issue comment <N> --body "Starting work on branch \`issue-<N>-<slug>\`"
+        │   - Add status label:
+        │     gh issue edit <N> --add-label "status:in-progress"
+        │
+        ├─► Step 3: Implement
+        │   - Make the changes based on acceptance criteria
+        │   - Build and test using the project's standard tooling
+        │     (Makefile, test framework, CI pipeline — whatever the project uses)
+        │   - Commit incrementally with clear messages
+        │
+        ├─► Step 4a: On Success
+        │   - Comment on issue:
+        │     gh issue comment <N> --body "Implementation complete, tests passing. Ready for PR."
+        │   - Progress is recorded on the issue, not the story — the story stays the
+        │     stable statement of the need
+        │   - Proceed to /dw-review-implement to gate the changes before the PR
+        │
+        ├─► Step 4b: On Failure
+        │   - Do NOT silently retry — update the issue:
+        │     gh issue comment <N> --body "Build/test failure: <what failed, error, root cause>"
+        │   - If blocked, add label:
+        │     gh issue edit <N> --add-label "status:blocked"
+        │   - Investigate, fix, update issue:
+        │     gh issue comment <N> --body "Applied fix: <what changed>. Retesting."
+        │   - Remove blocked label after unblocking:
+        │     gh issue edit <N> --remove-label "status:blocked"
+        │   - If stuck after 2-3 attempts, comment blockers and ask the user
+        │
+        └─► Step 4c: On Partial Fix
+            - Comment: what was fixed, what remains, blockers
+            - If the partial fix is independently useful: run /dw-review-implement,
+              then a human reviews + tests before a PR is opened (/dw-create-pr)
+            - Create follow-up issues for remaining work
+
+---
+
+## ISSUE CROSS-REFERENCES
+
+Use these patterns in issue comments and PR bodies:
+- **Parent/child**: "Part of #N" or "Parent: #N"
+- **Dependencies**: "Depends on #N", "Blocked by #N"
+- **Related**: "Related to #N"
+
+GitHub auto-creates backlinks when issues reference each other.
+
+---
+
+## EXAMPLE
+
+    /dw-implement 27
+
+**Agent reads issue #27, creates branch, implements:**
+
+    $ gh issue view 27
+    $ git checkout -b issue-27-release-notes   # from the repo's default branch
+    $ gh issue comment 27 --body "Starting work on branch `issue-27-release-notes`"
+    $ gh issue edit 27 --add-label "status:in-progress"
+
+    ... (implementation work) ...
+
+    $ gh issue comment 27 --body "Implementation complete, tests passing. Ready for PR."
+
+**Next step:** /dw-review-implement 27 (local gate). Then a human reviews + tests
+before a PR is opened (/dw-create-pr 27) — the workflow doesn't auto-advance to a PR.
+
+---
+
+## KEY PRINCIPLE
+
+The issue is the single source of truth. Anyone reading it should see the full
+history — start, failures, fixes, and resolution.
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for issue operations
+- Branch naming convention: `issue-<number>-<short-slug>`
+- Always comment on the issue before and after implementation
+- Label management: `status:in-progress` while working, `status:blocked` if stuck
+- For a planned task, the linked plan issue (`Part of #<plan>`) holds the agreed
+  approach — the checkpoint a fresh session resumes from (see
+  `.claude/rules/dev-workflow.md`)
+```

--- a/.claude/commands/dev-workflow/dw-merge.md
+++ b/.claude/commands/dev-workflow/dw-merge.md
@@ -1,0 +1,91 @@
+# Merge a Pull Request
+
+```
+Merge an approved pull request and clean up.
+
+PR number: {{input}}
+
+## PURPOSE
+
+Merges an approved PR, deletes the remote branch, cleans up local branches
+and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
+
+---
+
+## WORKFLOW
+
+    /dw-merge 30
+        │
+        ├─► Step 1: Verify Ready to Merge
+        │   - Run: gh pr view <PR> --json mergeStateStatus,headRefName,reviewDecision
+        │   - Must be mergeable (no conflicts)
+        │   - Run: gh pr checks <PR> — any CI checks must pass (if applicable)
+        │   - The merge gate is HUMAN review + test, not a GitHub approval. On a
+        │     solo repo GitHub blocks self-approval, so do NOT require
+        │     reviewDecision=APPROVED. Before merging, confirm a human has reviewed
+        │     and tested the change (its substance was gated by /dw-review-implement
+        │     before the PR). If not yet reviewed/tested, stop and say so.
+        │
+        ├─► Step 2: Identify Linked Issue and Story
+        │   - Read PR body for "Fixes #N" or "Closes #N"
+        │   - Note the issue number for label cleanup
+        │   - Check if PR body or issue title contains [STORY-XXX] or "Part of STORY-XXX"
+        │
+        ├─► Step 3: Merge
+        │   - Run: gh pr merge <PR> --merge --delete-branch
+        │   - Uses --merge (not squash/rebase) to preserve commit history
+        │   - --delete-branch cleans up the remote branch
+        │
+        ├─► Step 4: Clean Up Issue Labels
+        │   - Run: gh issue edit <N> --remove-label "status:needs-review"
+        │   - Issue auto-closes via "Fixes #N" — no manual close needed
+        │
+        ├─► Step 5: Update Story File (if linked)
+        │   - If linked to STORY-XXX and docs/stories/STORY-XXX.md exists:
+        │     • Check off completed acceptance criteria for this task
+        │     • If all story tasks are closed, mark story status as Completed
+        │   - Skip silently if no story link or docs/stories/ doesn't exist
+        │
+        ├─► Step 6: Clean Up Local Branch
+        │   - Switch to the repo's default branch and pull — derive it, don't
+        │     hardcode `main` (gh repo view --json defaultBranchRef -q
+        │     .defaultBranchRef.name): git checkout <default> && git pull
+        │   - Run: git branch -d <branch-name>
+        │
+        └─► Step 7: Report
+            - Confirm merge to the user
+            - Show the merged PR URL
+            - If story has remaining open tasks, suggest: /dw-implement <next-issue>
+            - If story is complete, mention it
+            - Mention any follow-up issues if applicable
+
+---
+
+## EXAMPLE
+
+    /dw-merge 30
+
+**Agent verifies, merges, cleans up:**
+
+    $ gh pr view 30 --json mergeStateStatus,headRefName,reviewDecision  # mergeable? (don't gate on self-approval)
+    $ gh pr checks 30
+    $ gh pr merge 30 --merge --delete-branch
+    $ gh issue edit 27 --remove-label "status:needs-review"
+    $ git checkout <default-branch> && git pull
+    $ git branch -d issue-27-release-notes
+
+**Output:**
+
+    PR #30 merged: https://github.com/owner/repo/pull/30
+    Issue #27 auto-closed.
+    Branch issue-27-release-notes deleted (local + remote).
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for PR and issue operations
+- `--merge` preserves full commit history (use `--squash` only if the project convention requires it)
+- `--delete-branch` removes the remote branch; `git branch -d` removes the local one
+- If PR is not approved or CI fails, report the blocker instead of merging
+```

--- a/.claude/commands/dev-workflow/dw-plan.md
+++ b/.claude/commands/dev-workflow/dw-plan.md
@@ -1,0 +1,135 @@
+# Plan Development Work into a Plan Issue
+
+```
+Research a story and write the plan — the agreed approach — as ONE GitHub plan
+issue, then stop for human review.
+
+Target: a STORY-XXX (or a raw request).
+
+## PURPOSE
+
+The front of the dev-workflow's build half: turn a story's *need* into an agreed
+*approach*, captured as a durable, reviewable **plan issue** before any task issue is
+opened. It researches against the repo (conventions, prior issues) so the plan is
+grounded, writes one plan issue, and **stops** — a human reviews the plan on GitHub,
+then `/dw-tasks` decomposes it. The plan issue is the parent of the task issues and the
+checkpoint a fresh session resumes from. See `.claude/rules/dev-workflow.md`.
+
+Fits in the dev-workflow:
+
+    dw-story → dw-review-story → dw-plan → [human reviews the plan issue]
+             → dw-tasks → dw-review-tasks → dw-implement → …
+
+This command produces the plan only. It does NOT create task issues — that is `/dw-tasks`.
+
+---
+
+## WORKFLOW
+
+    /dw-plan STORY-003
+        │
+        ├─► Step 1: Read the need (and right-size)
+        │   - If a STORY-XXX: read docs/stories/STORY-XXX.md (the need + "Success Looks Like").
+        │   - If a raw request: restate the need in a sentence.
+        │   - RIGHT-SIZE: if the work is trivial — a one-line change or a single,
+        │     obvious task — skip planning. Say so and hand off straight to
+        │     /dw-tasks (or a lone issue). The plan stage is for non-trivial stories.
+        │
+        ├─► Step 2: Research (ground the approach)
+        │   - Investigate the repo so the plan reflects it, not generic advice:
+        │     • conventions — CLAUDE.md, .claude/rules/, neighbouring code patterns
+        │     • prior art — gh issue list --state all --limit 50 ; related stories
+        │   - Note the approach, the commands/files it will touch, and open questions.
+        │
+        ├─► Step 3: Check for an existing plan
+        │   - Run: gh issue list --search "[STORY-XXX] Plan" --state all
+        │   - If a plan issue already exists, report and ask how to proceed (extend it,
+        │     not duplicate).
+        │
+        ├─► Step 4: Ensure labels (idempotent)
+        │   - plan           (color: #5319e7) — The approach for a story, before tasks
+        │   - priority:high / priority:medium / priority:low (as in /dw-tasks)
+        │   - Use: gh label create "<name>" --color "<hex>" --description "<desc>" --force
+        │
+        ├─► Step 5: Write ONE plan issue
+        │   - Title: [STORY-XXX] Plan   (raw request: "Plan: <short need>")
+        │   - Body: the template below — approach, acceptance criteria, the
+        │     commands/files it expects to touch, open questions.
+        │   - Labels: plan + priority. Link the story: "Part of STORY-XXX".
+        │
+        ├─► Step 6: Record on the story (if a STORY-XXX)
+        │   - Update docs/stories/STORY-XXX.md Status with the plan issue number:
+        │     - Plan: #<plan>
+        │
+        └─► Step 7: Hand off — stop for human review
+            - Show the plan issue URL.
+            - STOP. The plan now waits for a HUMAN to read, comment, and approve it on
+              GitHub. Do NOT create task issues and do NOT auto-advance.
+            - Once a human is satisfied: /dw-tasks STORY-XXX breaks the plan into tasks.
+
+---
+
+## PLAN ISSUE BODY TEMPLATE
+
+    ## Context
+    Part of [STORY-XXX](../docs/stories/STORY-XXX.md) — <the need, one line>.
+
+    ## Approach
+    <How we'll meet the need — the agreed shape of the work, grounded in the repo.>
+
+    ## Acceptance Criteria
+    - [ ] <observable outcome that means the story is delivered>
+
+    ## Touches
+    - <commands / files / areas the work is expected to change>
+
+    ## Open Questions
+    - <what's still unresolved — settled as the tasks are worked>
+
+---
+
+## EXAMPLE
+
+    /dw-plan STORY-003
+
+**Agent reads the story, researches, writes one plan issue:**
+
+    $ cat docs/stories/STORY-003.md
+    $ gh issue list --state all --limit 50
+    $ gh issue list --search "[STORY-003] Plan" --state all
+    $ gh label create "plan" --color "5319e7" --description "The approach for a story, before tasks" --force
+    $ gh issue create --label "plan" --label "priority:high" \
+        --title "[STORY-003] Plan" \
+        --body "## Context
+    Part of STORY-003 — validate inbound payloads.
+    ## Approach
+    ...
+    ## Acceptance Criteria
+    - [ ] ...
+    ## Touches
+    - ...
+    ## Open Questions
+    - ..."
+
+**Story file updated:**
+
+    ## Status
+    - Created: 2026-04-01
+    - Plan: #28
+
+**Output:**
+
+    Plan issue #28 created: https://github.com/owner/repo/issues/28
+    A human reviews + approves it; then /dw-tasks STORY-003 breaks it into tasks.
+
+---
+
+## API Notes
+
+- Uses `gh` CLI — must be authenticated (`gh auth status`)
+- Labels use `--force` so existing labels are updated, not duplicated
+- One plan issue per story — check for duplicates before creating
+- The plan issue is the parent of the task issues; the story records the need, the plan
+  records the approach, the task issues carry the how (see .claude/rules/dev-workflow.md)
+- Trivial work skips this command — go straight to /dw-tasks
+```

--- a/.claude/commands/dev-workflow/dw-review-implement.md
+++ b/.claude/commands/dev-workflow/dw-review-implement.md
@@ -1,0 +1,87 @@
+# Review an Implementation
+
+```
+Review the changes an issue was implemented with — do they deliver the issue, and
+do they stay surgical rather than sprawling beyond it?
+
+Issue number: {{input}}
+
+## PURPOSE
+
+Quality-gates the work done by `/dw-implement` before it becomes a PR. Checks that
+the changes on the branch **deliver the issue** (every "Done When" is actually
+satisfied) and stay **surgical** (every changed line traces to the issue — no scope
+creep, dead code, or debug leftovers) while **fitting the project**. Fixes small
+findings on the branch in place, or hands back to `/dw-implement` if the approach is
+wrong.
+
+Fits between `/dw-implement` (does the work) and `/dw-create-pr` (opens the PR):
+
+    … → dw-implement → dw-review-implement → dw-create-pr → …
+
+---
+
+## WORKFLOW
+
+    /dw-review-implement 27
+        │
+        ├─► Step 1: Gather
+        │   - Run: gh issue view <N> (the Goal + "Done When")
+        │   - If the title contains [STORY-XXX], read docs/stories/STORY-XXX.md
+        │     for the need behind the issue
+        │   - See what changed on the branch, against the repo's default branch:
+        │     git diff <default>...HEAD   (derive <default>, don't hardcode `main`)
+        │   - If there are no changes, report and stop (run /dw-implement first)
+        │
+        ├─► Step 2: Delivers the issue
+        │   - [ ] Every "Done When" box is actually satisfied by the changes —
+        │         observable, not asserted. Confirm by running the project's
+        │         standard tooling (build / test / render — whatever /dw-implement
+        │         used), not by reading the diff alone
+        │   - [ ] Nothing the issue asked for is missing or stubbed out
+        │   - [ ] The changes match the issue's Goal, not a different problem
+        │
+        ├─► Step 3: Surgical
+        │   - [ ] Every changed line traces to this issue — no unrelated refactors,
+        │         "improvements", or reformatting of adjacent code
+        │   - [ ] No scope creep beyond the issue's Goal (extra features, speculative
+        │         abstractions, config nobody asked for)
+        │   - [ ] No dead code, commented-out blocks, debug prints, or leftover TODOs
+        │   - [ ] Now-unused imports/vars/files the change created are removed
+        │
+        ├─► Step 4: Fits the project
+        │   - [ ] Matches the project's conventions and existing patterns/style
+        │   - [ ] Core stays target-agnostic — no vendor names/coupling leaked in
+        │         (vendor specifics belong in a profile)
+        │   - [ ] Markdown stays the source of truth; cross-references resolve to
+        │         files that exist
+        │   - [ ] The issue records the work (start / fixes / result) per /dw-implement
+        │
+        ├─► Step 5: Decision
+        │   - PASS: delivers the issue, surgical, fits → ready for a HUMAN to
+        │     review + test, then open a PR (/dw-create-pr <N>) — don't auto-advance
+        │   - REVISE: specific findings — fix on the branch, smallest blast radius
+        │     first (remove leaked scope, fill a gap, tighten); commit
+        │   - HAND BACK: the approach is wrong (wrong design, misread the issue) →
+        │     comment the issue and route back to /dw-implement
+        │
+        └─► Step 6: Report
+            - Per finding: the exact file:line + the smallest fix
+            - A delivery verdict against the issue's "Done When"
+            - The issue link + suggested next step
+
+---
+
+## API Notes
+
+- Uses `gh` to read the issue; reads the branch diff with `git` — read-mostly
+- Reviews the local implementation result before it becomes a PR — pairs with
+  /dw-implement the way /dw-review-tasks pairs /dw-tasks
+- This is the substance gate (delivers + surgical), run on the local diff before
+  the PR — there is no separate PR-review command. PR mechanics (linkage, labels)
+  are handled by /dw-create-pr and /dw-merge, and a human reviews + tests the PR
+  before merge.
+- Surgical-change bar mirrors the project's CLAUDE.md (every changed line traces to
+  the request; clean up only your own orphans)
+- When fixing, change only what a finding points to — don't rewrite sound work
+```

--- a/.claude/commands/dev-workflow/dw-review-pr.md
+++ b/.claude/commands/dev-workflow/dw-review-pr.md
@@ -1,0 +1,127 @@
+# Review a Pull Request
+
+```
+Review a pull request using a structured checklist.
+
+PR number: {{input}}
+
+## PURPOSE
+
+Reviews a pull request against a structured checklist covering issue linkage,
+code quality, test coverage, and documentation. Approves or requests changes.
+
+---
+
+## WORKFLOW
+
+    /dw-review-pr 30
+        │
+        ├─► Step 1: Read the PR
+        │   - Run: gh pr view <PR>
+        │   - Run: gh pr diff <PR>
+        │   - Run: gh pr checks <PR>
+        │
+        ├─► Step 2: Review Checklist
+        │
+        │   Issue Linkage:
+        │   - [ ] PR body contains "Fixes #N" or "Closes #N"
+        │   - [ ] PR title is clear and under 70 characters
+        │   - [ ] Labels match the linked issue
+        │
+        │   Code Quality:
+        │   - [ ] Changes match the issue's acceptance criteria
+        │   - [ ] No unnecessary changes beyond what was requested
+        │   - [ ] No security vulnerabilities (injection, hardcoded secrets)
+        │   - [ ] No debug/temporary code left in
+        │
+        │   Project-Type Checks (detect and apply relevant items):
+        │   - Detect project type by scanning for markers:
+        │     • src/mcpServer.ts or @modelcontextprotocol/sdk → MCP server
+        │     • package.json with react/next → Frontend
+        │     • Dockerfile or docker-compose.yml → Containerized
+        │     • pyproject.toml or setup.py → Python
+        │     • go.mod → Go
+        │
+        │   IF MCP server:
+        │   - [ ] Service function follows existing patterns in services/
+        │   - [ ] Tool registered with clear description (REQUIRED/PREREQUISITE refs)
+        │   - [ ] Async operations use standard retry/polling pattern
+        │   IF Frontend:
+        │   - [ ] No console.log left in production code
+        │   - [ ] Components follow existing patterns
+        │   IF Containerized:
+        │   - [ ] Dockerfile follows best practices (multi-stage, non-root)
+        │   - [ ] No secrets in image layers
+        │   IF Python:
+        │   - [ ] Type hints on public functions
+        │   - [ ] No bare except clauses
+        │   IF Go:
+        │   - [ ] Errors are checked, not discarded
+        │   - [ ] No goroutine leaks (context cancellation handled)
+        │   (Skip this section silently if no project type detected)
+        │
+        │   Test Coverage (adaptive — detect what the project uses):
+        │   - Detect CI: .github/workflows/, .gitlab-ci.yml, Jenkinsfile, .circleci/
+        │   - Detect test infra: cicd/tests/, tests/, __tests__/, *_test.go, *.robot
+        │
+        │   IF CI exists:
+        │   - [ ] CI pipeline passed (run: gh pr checks <PR>)
+        │   - [ ] New or updated test files match the scope of changes
+        │   - [ ] No test regressions in CI output
+        │   IF no CI:
+        │   - [ ] Manual test plan present in PR body or docs/test-plans/
+        │   - [ ] Test steps are specific and verifiable
+        │   - (Informational) Note: project has no CI — see /dw-test-design
+        │
+        │   Documentation:
+        │   - [ ] Comments added where logic isn't self-evident
+        │   - [ ] No unnecessary comments or docstrings
+        │
+        ├─► Step 3: Decision
+        │   - Approve: all checks pass → proceed to /dw-merge
+        │   - Request changes: specific feedback → back to /dw-implement
+        │
+        └─► Step 4: Submit Review
+            - Check if you are the PR author (GitHub blocks self-approval)
+            - If NOT the author:
+              gh pr review <PR> --approve --body "LGTM"
+            - If you ARE the author (self-review):
+              gh pr comment <PR> --body "Self-review complete. Checklist passes. Ready to merge."
+            - To request changes:
+              gh pr review <PR> --request-changes --body "<specific feedback>"
+
+---
+
+## EXAMPLE
+
+    /dw-review-pr 30
+
+**Agent reads PR, runs checklist:**
+
+    $ gh pr view 30
+    $ gh pr diff 30
+    $ gh pr checks 30
+
+**Checklist result:**
+
+    ✓ Issue linkage — Fixes #27 present
+    ✓ Title — "Add release notes generator command" (42 chars)
+    ✓ Code quality — Changes match acceptance criteria
+    ✓ No security issues
+    ✓ Tests — N/A (markdown-only change)
+
+    $ gh pr review 30 --approve --body "LGTM"
+
+**Output:**
+
+    PR #30 approved. Next: /dw-merge 30
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for PR operations
+- GitHub blocks self-approval — use comment instead if you authored the PR
+- If CI checks are failing, investigate before approving
+- Always read the full diff, not just the PR description
+```

--- a/.claude/commands/dev-workflow/dw-review-story.md
+++ b/.claude/commands/dev-workflow/dw-review-story.md
@@ -1,0 +1,96 @@
+# Review a User Story
+
+```
+Review a story for completeness and ensure it stays a goal document, not a spec.
+
+Story ID: {{input}}
+
+## PURPOSE
+
+Quality-gates a story written by `/dw-story` before it becomes work. Checks two
+things: the story is **complete** (every goal section is present and substantive),
+and it is a **goal document, not a spec** (it states the need and the outcome, and
+leaves the *how* to the GitHub issue). Reports findings and revises the story, or
+hands it back to `/dw-story` if the need itself is unclear.
+
+---
+
+## WORKFLOW
+
+    /dw-review-story STORY-001
+        │
+        ├─► Step 1: Read the Story
+        │   - If no story ID provided, list files in docs/stories/ and ask user to pick
+        │   - Read docs/stories/STORY-XXX.md
+        │   - If the story file doesn't exist, report and stop
+        │
+        ├─► Step 2: Completeness Checklist
+        │   - [ ] Title is specific (not a placeholder like "[Title]")
+        │   - [ ] User Story has a real role, action, AND benefit — the "so that"
+        │         is a genuine benefit, not a restatement of the action
+        │   - [ ] The Need explains the problem behind the request (the why), in the
+        │         user's terms — not how it will be built
+        │   - [ ] Success Looks Like lists outcomes someone could actually observe
+        │   - [ ] Open Questions captures what's genuinely unresolved (or says
+        │         "none known" — empty-because-skipped is a finding)
+        │   - [ ] Status has a Created date
+        │
+        ├─► Step 3: Goal-not-Spec Checklist
+        │   - [ ] No implementation detail in the body — no specific files, APIs,
+        │         frameworks, data shapes, or step-by-step "how"
+        │   - [ ] Success Looks Like describes observable user-facing results, not
+        │         implementation steps ("the project shows the stories", not "parse
+        │         markdown with X and render with Y")
+        │   - [ ] The technical / uncertain "how" lives in Open Questions, deferred
+        │         to the issue — it is not asserted as decided in the body
+        │   - [ ] No acceptance-criteria checklist acting as a build spec
+        │   - [ ] The whole story is decidable by someone who won't implement it
+        │
+        ├─► Step 4: Decision
+        │   - PASS: both checklists clear → report ✓ and suggest /dw-tasks STORY-XXX
+        │   - REVISE: list each finding with the exact line, then fix in place —
+        │     remove leaked spec, fill missing sections, reword success into outcomes
+        │   - HAND BACK: if the *need* itself is unclear or wrong (not just the
+        │     wording), stop and route to /dw-story to re-capture it with the user
+        │
+        └─► Step 5: Report
+            - Print the verdict (PASS / REVISED / HAND BACK) and the findings
+            - Print the path to the story and the suggested next step
+
+---
+
+## EXAMPLE
+
+    /dw-review-story STORY-001
+
+**Agent reads the story, runs both checklists:**
+
+    Completeness:
+    ✓ Title specific — "See the project's stories"
+    ✓ User Story — role + action + benefit all present
+    ✓ The Need — explains why (the project is the face over the markdown source of truth)
+    ✓ Success Looks Like — observable (the project shows stories, reflects changes)
+    ✓ Open Questions — presentation, status, read strategy all deferred
+    ✓ Status — Created date present
+
+    Goal-not-Spec:
+    ✓ No files/APIs/frameworks asserted in the body
+    ✓ Success is outcome-based, not implementation steps
+    ✓ The "how" sits in Open Questions
+    ✓ No build-spec checklist
+
+**Output:**
+
+    PASS — STORY-001 is complete and stays a goal.
+    docs/stories/STORY-001.md
+    Next: /dw-tasks STORY-001 to open the issue where the "how" gets decided.
+
+---
+
+## API Notes
+
+- Reads only the story file — no GitHub calls
+- The story is a goal; the issue is where the *how* and its history live (see
+  docs/stories/README.md)
+- When revising, change only what a finding points to — don't rewrite a sound story
+```

--- a/.claude/commands/dev-workflow/dw-review-tasks.md
+++ b/.claude/commands/dev-workflow/dw-review-tasks.md
@@ -1,0 +1,103 @@
+# Review the Tasks for a Story
+
+```
+Review the GitHub issues a story was broken into — do they cover the story, and does
+each stay a lean goal rather than a frozen spec?
+
+Story ID: {{input}}
+
+## PURPOSE
+
+Quality-gates the issues created by `/dw-tasks` before implementation starts. Checks
+that **together they cover the story**, and that **each is one small, testable job
+that leaves the *how* to develop on the issue** (not front-loaded as a spec). Fixes
+issue bodies / labels / links in place, or sends the breakdown back to `/dw-tasks` if
+it's wrong.
+
+Fits between `/dw-tasks` (creates issues) and `/dw-implement` (works one):
+
+    dw-story → dw-review-story → dw-plan → [human reviews the plan issue]
+             → dw-tasks → dw-review-tasks → dw-implement → …
+
+---
+
+## WORKFLOW
+
+    /dw-review-tasks STORY-001
+        │
+        ├─► Step 1: Gather
+        │   - If no story ID, list docs/stories/ and ask which to review
+        │   - Read docs/stories/STORY-XXX.md (the goal + "Success Looks Like")
+        │   - Find the plan issue (if any): note its number <plan> — none means
+        │     trivial work that skipped the plan stage:
+        │     gh issue list --search "[STORY-XXX] Plan" --label plan --state all
+        │   - List its task issues (the plan issue is the parent, not a task):
+        │     gh issue list --search "[STORY-XXX]" --state all --json number,title,labels,body
+        │   - If no issues exist, report and stop (run /dw-tasks first)
+        │
+        ├─► Step 2: Coverage — the issues vs the story (and plan)
+        │   - [ ] Every item in the story's "Success Looks Like" is covered by an issue
+        │   - [ ] Nothing essential to delivering the story is missing
+        │   - [ ] No issue goes beyond the story's goal — each traces back to the need
+        │   - [ ] When a plan exists: each task links back to it ("Part of #<plan>") —
+        │         flag any task missing the link. No plan → skip (trivial path).
+        │
+        ├─► Step 3: Each issue
+        │   - [ ] One clear job (title + Goal say one thing)
+        │   - [ ] Small enough to finish in a session; independent where it can be
+        │   - [ ] "Done When" is observable — checkable without ambiguity
+        │   - [ ] Body is lean (Context / Goal / Done When); the *how* is NOT frozen in
+        │         — it's left to develop on the issue (research / PoC / comments)
+        │   - [ ] Type + priority labels make sense
+        │
+        ├─► Step 4: Across the set
+        │   - [ ] No two issues substantially duplicate each other
+        │   - [ ] Dependencies/links are sane (no cycles) and the order is buildable
+        │
+        ├─► Step 5: Decision
+        │   - PASS: covers the story + each issue is clean → suggest /dw-implement <first>
+        │   - REVISE: specific fixes — edit the issue body / labels / links in place
+        │     (gh issue edit), or comment what's missing
+        │   - RE-SPLIT: the breakdown itself is wrong (gaps, wrong boundaries, overlap)
+        │     → back to /dw-tasks to re-decompose
+        │
+        └─► Step 6: Report
+            - Per issue: verdict + findings
+            - A coverage verdict against the story
+            - The story path + issue links + suggested next step
+
+---
+
+## EXAMPLE
+
+    /dw-review-tasks STORY-007
+
+**Agent reads the story + its issues, runs the checks:**
+
+    Coverage (vs the story's "Success Looks Like"):
+    ✓ <outcome A>  → #21
+    ✓ <outcome B>  → #22
+    ~ nothing essential missing; no issue exceeds the goal
+
+    Each issue:
+    ✓ #21 one job · Done When observable · lean body (Context / Goal / Done When)
+    ✓ #22 one job · Done When observable · lean body
+
+    Across the set: no overlap; deps are sane and the order is buildable
+
+**Output:**
+
+    PASS — the breakdown covers STORY-007 and each issue stays a goal.
+    Next: /dw-implement 21
+
+(Illustrative — a hypothetical clean breakdown. Real reviews often return REVISE.)
+
+---
+
+## API Notes
+
+- Uses `gh` to read (and, on REVISE, edit) the issues — read-mostly
+- The story is the goal; these issues are the agreed work — keep them lean, the how
+  lives in their comments/history (see docs/stories/README.md)
+- When fixing, change only what a finding points to — don't rewrite a sound breakdown
+```

--- a/.claude/commands/dev-workflow/dw-story.md
+++ b/.claude/commands/dev-workflow/dw-story.md
@@ -1,0 +1,84 @@
+# Create User Story
+
+Create a user story file from user input.
+
+```
+{{input}}
+
+## PURPOSE
+
+Capture the user's **need** as a story file saved to `docs/stories/`. A story is a
+**goal, not a spec** — it states what the user needs and why, and leaves the *how*
+open. Implementation detail (affected files, APIs, design) is worked out later on the
+GitHub issue, not here. See `docs/stories/README.md`.
+
+---
+
+## AGENT WORKFLOW
+
+### Step 1: Determine Story ID
+
+Check `docs/stories/` for existing story files. Generate the next sequential ID:
+- Format: `STORY-XXX` (e.g., STORY-001, STORY-002)
+- If no stories exist, start with STORY-001
+
+### Step 2: Clarify the Need
+
+If the user input is vague, ask questions that sharpen the **need** — not the
+implementation:
+- Who is the user, and what are they trying to achieve?
+- Why does it matter — what's the benefit or the problem behind the request?
+- What would success look like from their point of view?
+
+Do **not** ask about affected files, edge cases, or design here — that gets worked
+out on the issue. If the need is clear enough, proceed directly.
+
+### Step 3: Write Story File
+
+Create `docs/stories/STORY-XXX.md` with this template:
+
+```markdown
+# STORY-XXX: [Title]
+
+## User Story
+
+As a [role],
+I want to [action],
+So that [benefit].
+
+## The Need
+
+[The problem behind the request — what the user is trying to achieve and why, in
+their terms.]
+
+## Success Looks Like
+
+[The outcome that means this is done, described as observable user-facing results —
+not implementation steps.]
+
+## Open Questions
+
+[What still has to be figured out — resolved later on the GitHub issue via research,
+proof of concept, or clarification. The "how" goes here, not above.]
+
+## Status
+
+- Created: [date]
+- Issues: none
+```
+
+### Step 4: Confirm
+
+Show the user the created story and suggest next steps:
+- `/dw-review-story STORY-XXX` to check it's complete and still a goal, not a spec
+- `/dw-plan STORY-XXX` to research the approach and write the plan issue (the agreed
+  *how*), reviewed before it's broken into tasks
+- Trivial / single-task work can skip the plan — `/dw-tasks STORY-XXX` straight away
+- `/qw-plan` to plan what to test (if QA-related)
+
+---
+
+## OUTPUT
+
+The path to the created story file.
+```

--- a/.claude/commands/dev-workflow/dw-tasks.md
+++ b/.claude/commands/dev-workflow/dw-tasks.md
@@ -1,0 +1,135 @@
+# Break a Plan into GitHub Task Issues
+
+```
+Break a reviewed plan (or a story) into GitHub task issues, each linked back to it.
+
+Story ID: {{input}}
+
+## PURPOSE
+
+Reads the reviewed **plan issue** for a story (`[STORY-XXX] Plan`, written by `/dw-plan`)
+and breaks its approach into implementable GitHub task issues, each linking back to the
+plan. When no plan issue exists — trivial work that skipped the plan stage — it falls
+back to breaking the story directly. Updates the story file with the created issue
+numbers. See `.claude/rules/dev-workflow.md`.
+
+Fits in the dev-workflow:
+
+    dw-story → dw-review-story → dw-plan → [human reviews the plan issue]
+             → dw-tasks → dw-review-tasks → dw-implement → …
+
+---
+
+## WORKFLOW
+
+    /dw-tasks STORY-003
+        │
+        ├─► Step 1: Read the plan (or the story)
+        │   - If no story ID provided, list files in docs/stories/ and ask user to pick
+        │   - Read docs/stories/STORY-XXX.md for the need + "Success Looks Like"
+        │   - Find the reviewed plan issue:
+        │     gh issue list --search "[STORY-XXX] Plan" --label plan --state open
+        │     • If found: read it — its Approach + Acceptance Criteria are what you
+        │       break into tasks (the plan is the agreed how). Note its number <plan>.
+        │     • If none: fall back to breaking the story directly (trivial work that
+        │       skipped the plan stage). <plan> is empty.
+        │   - If the story file doesn't exist, report and stop
+        │
+        ├─► Step 2: Break into Tasks
+        │   - Break the plan's approach (or the story, when no plan) into tasks
+        │   - Each task should be:
+        │     • Small — completable in one session
+        │     • Independent — minimal dependencies between tasks
+        │     • Testable — has a clear done condition
+        │   - Detect project type to suggest task breakdown:
+        │     • Check project structure, CLAUDE.md, and existing code patterns
+        │     • Use these to inform sensible task boundaries
+        │   - Present the proposed task list to the user for approval
+        │
+        ├─► Step 3: Check for Duplicates
+        │   - Run: gh issue list --search "[STORY-XXX]" --state all
+        │   - If matching issues exist, report and ask user how to proceed
+        │
+        ├─► Step 4: Create Labels (idempotent)
+        │   - Ensure labels exist (same as /dw-plan):
+        │     • type labels: feature, enhancement, bug, docs
+        │     • priority labels: priority:high, priority:medium, priority:low
+        │     • status labels: status:in-progress, status:needs-review, status:blocked
+        │   - Use: gh label create "<name>" --color "<hex>" --force
+        │
+        ├─► Step 5: Create GitHub Issues
+        │   - One issue per task
+        │   - Title: [STORY-XXX] Task description
+        │   - Body — start lean; the issue grows as the *how* is worked out
+        │     (research, PoC, clarification, fixes) and recorded in comments:
+        │       ## Context
+        │       Part of [STORY-XXX](../docs/stories/STORY-XXX.md) · plan #<plan>
+        │
+        │       ## Goal
+        │       [what this task achieves, from the plan's approach / the story's need]
+        │
+        │       ## Done When
+        │       - [ ] [observable done condition for this task]
+        │   - Labels: type + priority (infer from the plan / story content)
+        │   - Trace back: "Part of #<plan>" in the body links each task to the plan
+        │     issue (GitHub backlinks it). Omit the plan reference when there is none.
+        │
+        ├─► Step 6: Update Story File
+        │   - Update the Status section in docs/stories/STORY-XXX.md:
+        │     ## Status
+        │     - Created: [original date]
+        │     - Issues: #1, #2, #3
+        │
+        └─► Step 7: Report
+            - Show table of created issues:
+              | Issue | Title | Type | Priority |
+            - Suggest implementation order based on dependencies
+            - Suggest: /dw-review-tasks STORY-XXX to gate the breakdown, then
+              /dw-implement <N> to start on the first task
+
+---
+
+## EXAMPLE
+
+    /dw-tasks STORY-003
+
+**Agent reads the plan, breaks it into tasks, creates issues:**
+
+    $ cat docs/stories/STORY-003.md
+    $ gh issue list --search "[STORY-003] Plan" --label plan --state open   # → plan #28
+    $ gh issue list --search "[STORY-003]" --state all                      # dup check
+    $ gh issue create --title "[STORY-003] Add input validation" \
+        --label "enhancement" --label "priority:high" \
+        --body "## Context\nPart of STORY-003 · plan #28\n\n## Goal\n...\n\n## Done When\n- [ ] ..."
+    $ gh issue create --title "[STORY-003] Add error response formatting" \
+        --label "enhancement" --label "priority:medium" \
+        --body "..."
+
+**Story file updated:**
+
+    ## Status
+    - Created: 2026-04-01
+    - Issues: #15, #16
+
+**Output:**
+
+    | Issue | Title                              | Type        | Priority |
+    |-------|------------------------------------|-------------|----------|
+    | #15   | [STORY-003] Add input validation   | enhancement | high     |
+    | #16   | [STORY-003] Add error formatting   | enhancement | medium   |
+
+    Suggested order: #15 → #16
+    Start: /dw-implement 15
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for issue operations
+- Story files live in `docs/stories/STORY-XXX.md` (created by /dw-story)
+- Issue titles use `[STORY-XXX]` prefix for traceability
+- The reviewed plan issue (`[STORY-XXX] Plan`, from /dw-plan) is the source for the
+  breakdown when present, and each task links back to it; no plan → break the story
+- The story file records the need; the issue is the single source of truth for *how*,
+  growing with research, decisions, and fixes as the work proceeds
+```

--- a/.claude/commands/dev-workflow/dw-test-design.md
+++ b/.claude/commands/dev-workflow/dw-test-design.md
@@ -1,0 +1,188 @@
+# Design Tests for a GitHub Issue
+
+```
+Write tests after implementation, adapted to the project's existing test infrastructure.
+
+Issue number: {{input}}
+
+## PURPOSE
+
+After implementation is complete, this command designs and writes tests that verify
+the changes. It detects what test infrastructure the project uses and generates
+tests in the native format. If no test infrastructure exists, it writes a manual
+test checklist and recommends adopting a test framework.
+
+Fits into the dev-workflow chain after /dw-implement and before /dw-create-pr.
+
+---
+
+## WORKFLOW
+
+    /dw-test-design 47
+        │
+        ├─► Step 1: Understand What Was Implemented
+        │   - Run: gh issue view <N>
+        │   - Read the acceptance criteria and technical notes
+        │   - See what changed vs the repo's default branch — derive it, don't
+        │     hardcode `main` (gh repo view --json defaultBranchRef -q
+        │     .defaultBranchRef.name): git log --oneline <default>..HEAD and
+        │     git diff <default> --stat
+        │   - Identify what needs test coverage
+        │
+        ├─► Step 2: Detect Test Infrastructure
+        │   - Scan the project for existing test tooling:
+        │
+        │     Test Frameworks:
+        │     - cicd/tests/testcases/**/*.yml     → test-framework-template (YAML + dual-judge)
+        │     - tests/ + pytest.ini or conftest.py → pytest
+        │     - __tests__/ or *.test.ts/js         → Jest
+        │     - *.spec.ts/js                       → Jest / Vitest / Mocha
+        │     - *.robot                            → Robot Framework
+        │     - *_test.go                          → Go test
+        │     - **/*Test.java or **/*Spec.java     → JUnit / TestNG
+        │     - tests/ + Cargo.toml                → Rust (cargo test)
+        │
+        │     Test Runners (check even if no test files found):
+        │     - package.json → scripts.test        → npm test
+        │     - Makefile → test target             → make test
+        │     - pyproject.toml → [tool.pytest]     → pytest
+        │     - tox.ini                            → tox
+        │
+        │     CI Pipelines:
+        │     - .github/workflows/                 → GitHub Actions
+        │     - .gitlab-ci.yml                     → GitLab CI
+        │     - Jenkinsfile                        → Jenkins
+        │     - .circleci/                         → CircleCI
+        │     - .travis.yml                        → Travis CI
+        │
+        │   - Record findings: which framework, which runner, which CI
+        │
+        ├─► Step 3: Detect Issue Type (for test scope)
+        │   - Read labels from the GitHub issue:
+        │     - feature, epic, story       → Type A: broad coverage
+        │     - bug, defect                → Type B: regression test targeting the fix
+        │     - enhancement, improvement   → Type C: tests for changed behavior
+        │   - If no label matches, infer from issue title and description
+        │
+        ├─► Step 4: Generate Tests
+        │
+        │   ┌─ IF test infrastructure found:
+        │   │  - Write tests in the project's native format
+        │   │  - Place files where the project's existing tests live
+        │   │  - Follow existing naming conventions and patterns
+        │   │  - Run the project's test command to verify tests pass
+        │   │  - Commit test files to the issue branch
+        │   │
+        │   │  Examples by framework:
+        │   │  - test-framework-template → YAML in cicd/tests/testcases/{suite}/
+        │   │  - pytest   → Python test files in tests/
+        │   │  - Jest     → *.test.ts in __tests__/ or co-located
+        │   │  - Go test  → *_test.go alongside source files
+        │   │  - Robot    → *.robot in tests/ or robot/
+        │   │
+        │   └─ IF no test infrastructure found:
+        │      - Write a manual test checklist in the PR body (Step 5 will use it)
+        │      - Format as markdown checklist:
+        │        ## Test Plan
+        │        - [ ] Step 1: description → expected result
+        │        - [ ] Step 2: description → expected result
+        │      - Add a recommendation note:
+        │        > This project has no automated test infrastructure.
+        │        > Consider adopting [test-framework-template](https://github.com/dogkeeper886/test-framework-template)
+        │        > for YAML-driven CI testing with dual-judge verification.
+        │      - Ask the user: "Want me to create a follow-up issue for CI setup?"
+        │        If yes → create issue labeled "enhancement" + "testing"
+        │
+        ├─► Step 5: Report
+        │   - Summarize what was created:
+        │     - Test framework detected (or "none")
+        │     - CI detected (or "none")
+        │     - Files created/modified
+        │     - Test run result (if applicable)
+        │   - If tests were written, show the test run output
+        │   - Suggest: proceed to /dw-create-pr
+        │
+        └─► Step 5b: On Test Failure
+            - If generated tests fail, investigate:
+              - Is the implementation incomplete?
+              - Is the test expectation wrong?
+            - Fix tests or flag implementation gap to the user
+            - Do not proceed to /dw-create-pr with failing tests
+
+---
+
+## EXAMPLE 1: Project with test-framework-template
+
+    /dw-test-design 47
+
+**Agent detects cicd/tests/testcases/ with YAML files:**
+
+    Detected: test-framework-template (YAML + dual-judge)
+    CI: GitHub Actions (.github/workflows/test-pipeline.yml)
+    Issue #47: enhancement → Type C (changed behavior)
+
+**Generates YAML test case:**
+
+    Created: cicd/tests/testcases/integration/TC-INTEGRATION-002.yml
+    Running: npm test -- --suite integration --no-llm
+    Result: 2 tests passed (0 failed)
+
+    Next: /dw-create-pr 47
+
+---
+
+## EXAMPLE 2: Project with pytest
+
+    /dw-test-design 12
+
+**Agent detects tests/ + conftest.py:**
+
+    Detected: pytest (tests/conftest.py found)
+    CI: GitHub Actions (.github/workflows/ci.yml)
+    Issue #12: bug → Type B (regression test)
+
+**Generates pytest file:**
+
+    Created: tests/test_issue_12_login_fix.py
+    Running: pytest tests/test_issue_12_login_fix.py -v
+    Result: 3 tests passed
+
+    Next: /dw-create-pr 12
+
+---
+
+## EXAMPLE 3: Project with no test infrastructure
+
+    /dw-test-design 5
+
+**Agent finds no test framework or CI:**
+
+    Detected: no test framework
+    CI: none
+
+    Wrote manual test checklist (will be included in PR body):
+    ## Test Plan
+    - [ ] Navigate to settings page → form loads without errors
+    - [ ] Change display name → saves and shows success message
+    - [ ] Enter invalid email → shows validation error
+
+    > This project has no automated test infrastructure.
+    > Consider adopting [test-framework-template](https://github.com/dogkeeper886/test-framework-template)
+    > for YAML-driven CI testing with dual-judge verification.
+
+    Create follow-up issue for CI setup? [y/n]
+
+    Next: /dw-create-pr 5
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for issue operations
+- Test detection is file-based — scans project root for known patterns
+- Does not install or configure test frameworks — only generates test files
+  for what already exists
+- When multiple test frameworks coexist, prefer the one closest to the
+  changed files
+- Always run tests locally before committing to catch generation errors
+```

--- a/.claude/commands/testlink/tl-add-case-to-plan.md
+++ b/.claude/commands/testlink/tl-add-case-to-plan.md
@@ -1,0 +1,174 @@
+# Add Test Case to Test Plan
+
+```
+Add a test case to a test plan in TestLink with proper validation and error handling.
+
+## Agent Instructions:
+1. Extract test case and test plan data from user input
+2. Validate all required fields before API call
+3. Use correct ID formats (external for test case, numeric for plan/project)
+4. Call TestLink MCP add_test_case_to_test_plan tool with validated data
+5. Handle common errors and provide clear feedback
+
+## Expected User Input Format:
+User should provide:
+- Test Case ID (external format like "PROJ-1" or numeric like "5")
+- Test Plan ID (numeric)
+- Test Project ID (numeric)
+- Urgency Level (optional, 1=low, 2=medium, 3=high)
+- Platform ID (optional)
+- Overwrite Flag (optional, true/false)
+
+## Agent Processing Steps:
+1. **Validate Input**: Check for required fields (testcaseid, testplanid, testprojectid)
+2. **Validate IDs**: Ensure test case exists and test plan exists
+3. **Check Assignment**: Verify test case is not already assigned (unless overwrite=true)
+4. **Format Data**: Prepare data object with correct field names
+5. **Call API**: Use add_test_case_to_test_plan tool with validated data
+6. **Handle Errors**: Provide clear error messages for common issues
+
+## Example Usage:
+**User Input:**
+```
+Add test case PROJ-1 to test plan 10
+Project: 1
+Urgency: High
+```
+
+**Agent Processing:**
+1. Extract: testcaseid="PROJ-1", testplanid="10", testprojectid="1", urgency="High"
+2. Validate: Check test case exists, test plan exists
+3. Check: Verify test case not already assigned
+4. Format: urgency=3 (convert High to 3)
+5. Call: add_test_case_to_test_plan with validated data
+6. Verify: Check assignment was successful
+
+**API Notes:**
+- testcaseid: Use external format (PROJ-1) or numeric ID
+- testplanid: Must be numeric ID
+- testprojectid: Must be numeric ID
+- urgency: 1=low, 2=medium, 3=high (defaults to 2)
+- overwrite: true/false (defaults to false)
+
+## Common Errors & Solutions:
+
+### ❌ "Missing required fields"
+**Cause**: Missing testcaseid, testplanid, or testprojectid
+**Solution**: Ensure all required fields are provided
+
+### ❌ "Test case not found"
+**Cause**: Invalid test case ID or test case doesn't exist
+**Solution**: Verify test case exists using read_test_case or list_test_cases_in_suite
+
+### ❌ "Test plan not found"
+**Cause**: Invalid test plan ID or test plan doesn't exist
+**Solution**: Verify test plan exists using list_test_plans
+
+### ❌ "Test case already assigned"
+**Cause**: Test case already linked to test plan
+**Solution**: Use overwrite=true to replace existing assignment
+
+### ❌ "Test case not in project"
+**Cause**: Test case belongs to different project than test plan
+**Solution**: Verify test case and test plan are in same project
+
+## Required Fields:
+- testcaseid: String (external format like "PROJ-1" or numeric like "5")
+- testplanid: String (numeric test plan ID)
+- testprojectid: String (numeric project ID)
+
+## Optional Fields:
+- version: Number (test case version, defaults to 1)
+- platformid: String (platform ID for multi-platform test plans)
+- urgency: Number (1=low, 2=medium, 3=high, defaults to 2)
+- overwrite: Boolean (replace existing assignment, defaults to false)
+
+## Step-by-Step Process:
+
+### 1. Validate Test Case
+- Use read_test_case to verify test case exists
+- Extract project ID from test case if not provided
+- Confirm test case is active and accessible
+
+### 2. Validate Test Plan
+- Use list_test_plans to verify test plan exists
+- Confirm test plan is active
+- Verify test plan belongs to correct project
+
+### 3. Check Existing Assignment
+- Use get_test_cases_for_test_plan to check if already assigned
+- If assigned and overwrite=false, inform user
+- If assigned and overwrite=true, proceed with assignment
+
+### 4. Prepare Assignment Data
+- Format urgency level (High=3, Medium=2, Low=1)
+- Set overwrite flag appropriately
+- Include platform ID if specified
+
+### 5. Execute Assignment
+- Call add_test_case_to_test_plan with prepared data
+- Handle any API errors gracefully
+- Verify assignment was successful
+
+## Urgency Level Mapping:
+- **1** = Low priority
+- **2** = Medium priority (default)
+- **3** = High priority
+
+## Best Practices:
+✅ Always validate test case and test plan exist before assignment
+✅ Check for existing assignments to avoid duplicates
+✅ Use appropriate urgency levels based on test importance
+✅ Verify test case and test plan are in same project
+✅ Use overwrite=true only when replacing existing assignments
+✅ Provide clear feedback on assignment success/failure
+
+## Error Handling Examples:
+
+**Missing Fields Error:**
+```
+❌ Error: Missing required fields: testcaseid, testplanid, testprojectid
+✅ Solution: Ensure all required fields are provided
+```
+
+**Test Case Not Found Error:**
+```
+❌ Error: Test case not found
+✅ Solution: Verify test case exists using read_test_case
+```
+
+**Already Assigned Error:**
+```
+❌ Error: Test case already assigned to test plan
+✅ Solution: Use overwrite=true to replace existing assignment
+```
+
+## Agent Response Template:
+
+**When assignment succeeds:**
+```
+Test case successfully added to test plan!
+
+Assignment Details:
+- Test Case: [test_case_name] (ID: [testcaseid])
+- Test Plan: [test_plan_name] (ID: [testplanid])
+- Project: [project_name] (ID: [testprojectid])
+- Urgency: [urgency_level]
+- Assignment ID: [feature_id]
+
+Test case is now available for execution in the test plan.
+```
+
+**When handling errors:**
+```
+❌ Failed to add test case to test plan: [error_message]
+
+Troubleshooting:
+1. Verify test case exists and is accessible
+2. Check test plan exists and is active
+3. Ensure test case and test plan are in same project
+4. Use overwrite=true if test case already assigned
+5. Verify all required fields are provided
+
+Would you like me to help resolve this issue?
+```

--- a/.claude/commands/testlink/tl-create-case.md
+++ b/.claude/commands/testlink/tl-create-case.md
@@ -1,0 +1,105 @@
+# Create TestLink Test Case
+
+```
+Create new test case in TestLink with proper HTML formatting and TestLink compliance.
+
+## Agent Instructions:
+1. Extract test case data from user input
+2. Apply HTML formatting according to guidelines below
+3. Generate external ID automatically or use provided format
+4. Call TestLink MCP create_test_case tool with formatted data
+5. If preconditions are missing after creation, use update_test_case to add them
+
+## Expected User Input Format:
+User should provide:
+- Test Suite ID (where to create the test case)
+- Test Case Name
+- Summary/Test Objective
+- Pre-conditions (optional)
+- Test Steps with Actions and Expected Results
+- Author Login (optional, defaults to "admin")
+
+## Agent Processing Steps:
+1. **Validate Input**: Check for required fields (suite ID, name, summary)
+2. **Generate External ID**: Create project prefix format (e.g., "PROJ-1", "PROJ-2")
+3. **Format Summary**: Wrap in <p> tags, apply <strong> for emphasis
+4. **Format Preconditions**: Convert to <ul><li> list format
+5. **Format Steps**: Apply HTML formatting to actions and expected results
+6. **Apply HTML Entities**: Convert >, <, ", &, ' to proper entities
+7. **Call API**: Use create_test_case tool with formatted data
+8. **Post-Creation**: If preconditions missing, call update_test_case
+
+## Example Usage:
+**User Input:**
+```
+Create test case in suite 12
+Name: User Authentication Test
+Summary: Verify user can authenticate with valid credentials
+Pre-conditions:
+- Valid user account exists
+- Authentication service is running
+- Login page is accessible
+Steps:
+1. Navigate to login page
+2. Enter valid username and password
+3. Click Login button
+Expected: User successfully logs in and redirected to dashboard
+```
+
+**Agent Processing:**
+1. Extract: suiteId="12", name="User Authentication Test", etc.
+2. Generate: externalId="PROJ-1" (auto-generated)
+3. Format summary: "<p>Verify user can <strong>authenticate</strong> with valid credentials</p>"
+4. Format preconditions: "<ul><li>Valid user account exists</li><li>Authentication service is running</li><li>Login page is accessible</li></ul>"
+5. Format steps with HTML entities and proper tags
+6. Call: create_test_case with formatted data
+7. Check if preconditions were applied, update if needed
+
+**API Notes:**
+- createTestCase may not process preconditions properly - update after creation
+- External ID will be auto-generated if not provided
+- Test case will be created in specified test suite
+- Author defaults to "admin" if not specified
+
+HTML Formatting:
+- Apply formatting per `/tl-format` rules (summary, preconditions, actions, expected results, entities)
+
+Required Step Fields (handled automatically):
+- step_number: String or number ("1", "2", "3", etc.)
+- actions: String with proper HTML formatting
+- expected_results: String with proper HTML formatting
+- active: Integer (always 1 for active steps)
+- execution_type: Integer (1 = manual, 2 = automated)
+
+Required Create Fields:
+- testprojectid: String (project ID)
+- testsuiteid: String (test suite ID)
+- name: String (test case name)
+- authorlogin: String (author login, defaults to "admin")
+- summary: String (HTML formatted summary)
+- preconditions: String (HTML formatted preconditions)
+- steps: Array (formatted step objects)
+- importance: Integer (1=low, 2=medium, 3=high, defaults to 3)
+- execution_type: Integer (1=manual, 2=automated, defaults to 1)
+- status: Integer (1=draft, 7=final, defaults to 7)
+
+Best Practices:
+✅ Use <strong> for UI elements like buttons, menus, fields
+✅ Use <em> for alternatives or clarifications
+✅ Use <br>• for simple multi-line expected results
+✅ Use <ul><li> for complex validation lists
+✅ Apply HTML entities for all special characters
+✅ Keep actions clear and concise with proper formatting
+✅ Make expected results specific and measurable
+✅ Always verify creation was successful by reading the test case
+✅ Check if preconditions were applied after creation
+✅ Update preconditions separately if missing after creation
+✅ Use descriptive external IDs (auto-generated with project prefix)
+
+Common Issues & Solutions:
+❌ "Missing required fields" → Ensure testprojectid, testsuiteid, name, authorlogin are provided
+❌ "Invalid test suite ID" → Verify suite exists in the project
+❌ Missing preconditions after creation → Use update_test_case to add preconditions
+❌ HTML not rendering → Check HTML entity usage (&gt;, &lt;, &quot;, &apos;)
+❌ "Test case already exists" → Use update_test_case instead or change name
+```

--- a/.claude/commands/testlink/tl-create-execution.md
+++ b/.claude/commands/testlink/tl-create-execution.md
@@ -1,0 +1,188 @@
+# Create TestLink Test Execution
+
+```
+Create new test execution in TestLink with proper status and execution data.
+
+## Agent Instructions:
+1. Extract test execution data from user input
+2. Use NUMERIC test case ID (not external ID format)
+3. Validate all required fields before API call
+4. Call TestLink MCP create_test_execution tool with validated data
+5. Handle common errors and provide clear feedback
+
+## Expected User Input Format:
+User should provide:
+- Test Case ID (NUMERIC format like "13", not "USM-1")
+- Test Plan ID (numeric)
+- Build ID (numeric)
+- Execution Status (p/f/b for pass/fail/block)
+- Execution Notes (optional)
+- Platform ID (optional)
+
+## Agent Processing Steps:
+1. **Validate Input**: Check for required fields (test_case_id, plan_id, build_id, status)
+2. **Convert Test Case ID**: Use numeric ID, not external format
+3. **Validate Status**: Ensure status is valid (p/f/b)
+4. **Format Notes**: Clean up execution notes
+5. **Call API**: Use create_test_execution tool with validated data
+6. **Handle Errors**: Provide clear error messages for common issues
+
+## Example Usage:
+**User Input:**
+```
+Create test execution for test case PROJ-1
+Test Plan: 10
+Build: 2
+Status: Pass
+Notes: All validations completed successfully
+```
+
+**Agent Processing:**
+1. Extract: testCaseId="PROJ-1", planId="10", buildId="2", status="Pass"
+2. Convert: testCaseId="5" (numeric ID from external format)
+3. Validate: status="p" (convert to single letter)
+4. Format: notes="All validations completed successfully"
+5. Call: create_test_execution with validated data
+6. Verify: Check creation was successful
+
+**API Notes:**
+- MUST use numeric test case ID (e.g., "5") not external format (e.g., "PROJ-1")
+- Test case must be assigned to the test plan first
+- Build must exist and be active/open
+- Status must be single letter: p=pass, f=fail, b=block
+
+## Common Errors & Solutions:
+
+### ❌ "Test Case ID (testcaseid: 1) provided does not exist"
+**Cause**: Using external ID format (PROJ-1) instead of numeric ID
+**Solution**: Convert external ID to numeric ID
+- PROJ-1 → 5
+- PROJ-2 → 10
+- PROJ-3 → 15
+- PROJ-4 → 20
+
+### ❌ "Missing required fields"
+**Cause**: Missing test_case_id, plan_id, build_id, or status
+**Solution**: Ensure all required fields are provided
+
+### ❌ "Test case not assigned to test plan"
+**Cause**: Test case not linked to the specified test plan
+**Solution**: Use add_test_case_to_test_plan first
+
+### ❌ "Build not found or inactive"
+**Cause**: Build ID doesn't exist or is closed
+**Solution**: Verify build exists and is active using list_builds
+
+## Status Values:
+- **p** = Pass (test execution successful)
+- **f** = Fail (test execution failed)
+- **b** = Block (test execution blocked)
+
+## Required Fields:
+- test_case_id: String (NUMERIC ID like "5", not "PROJ-1")
+- plan_id: String (test plan ID)
+- build_id: String (build ID)
+- status: String (p/f/b)
+- notes: String (execution notes, optional)
+- platform_id: String (platform ID, optional)
+
+## Step-by-Step Process:
+
+### 1. Get Test Case Numeric ID
+If user provides external ID (PROJ-1), convert to numeric:
+- Use list_test_cases_in_suite to find numeric ID
+- Or use read_test_case with external ID to get internal ID
+
+### 2. Validate Test Plan and Build
+- Verify test plan exists using list_test_plans
+- Verify build exists and is active using list_builds
+
+### 3. Check Test Case Assignment
+- Use get_test_cases_for_test_plan to verify test case is assigned
+- If not assigned, use add_test_case_to_test_plan first
+
+### 4. Create Execution
+- Call create_test_execution with validated data
+- Handle any remaining errors gracefully
+
+## Execution Notes Format:
+
+Write clear, descriptive notes for each result:
+
+**PASS notes:**
+```
+All steps completed successfully. [Feature] behaves as expected.
+Step 3 observation: [specific detail].
+```
+
+**FAIL notes:**
+```
+Failed at Step [N]: Expected "[expected result]" but got "[actual result]".
+Screenshot captured for evidence.
+[Additional context about the failure]
+```
+
+**BLOCKED notes:**
+```
+Blocked by: [reason].
+Could not execute because [dependency/prerequisite issue].
+```
+
+## Best Practices:
+✅ Always use numeric test case IDs
+✅ Validate all IDs exist before creating execution
+✅ Use clear, descriptive execution notes
+✅ Check test case assignment to test plan
+✅ Verify build is active before execution
+✅ Use appropriate status values (p/f/b)
+✅ Handle errors with clear user feedback
+
+## Error Handling Examples:
+
+**External ID Error:**
+```
+❌ Error: Test Case ID (testcaseid: 1) provided does not exist
+✅ Solution: Convert PROJ-1 to numeric ID 5
+```
+
+**Missing Assignment Error:**
+```
+❌ Error: Test case not assigned to test plan
+✅ Solution: Use add_test_case_to_test_plan first
+```
+
+**Invalid Build Error:**
+```
+❌ Error: Build not found
+✅ Solution: Check build exists with list_builds
+```
+
+## Agent Response Template:
+
+**When creating test execution:**
+```
+Test execution created successfully!
+
+Execution Details:
+- Execution ID: [execution_id]
+- Test Case: [test_case_name] (ID: [numeric_id])
+- Test Plan: [test_plan_name] (ID: [plan_id])
+- Build: [build_name] (ID: [build_id])
+- Status: [status_description]
+- Notes: [execution_notes]
+
+Execution recorded in TestLink system.
+```
+
+**When handling errors:**
+```
+❌ Test execution failed: [error_message]
+
+Troubleshooting:
+1. Verify test case ID is numeric (not external format)
+2. Check test case is assigned to test plan
+3. Verify build exists and is active
+4. Ensure all required fields are provided
+
+Would you like me to help resolve this issue?
+```

--- a/.claude/commands/testlink/tl-create-plan.md
+++ b/.claude/commands/testlink/tl-create-plan.md
@@ -1,0 +1,163 @@
+# Create TestLink Test Plan
+
+```
+Create new test plan in TestLink with plain text formatting and TestLink compliance.
+
+## Agent Instructions:
+1. Extract test plan data from user input
+2. **DO NOT apply HTML formatting** - TestLink API doesn't support it for test plans
+3. Use project name (not prefix) for project identification
+4. Call TestLink MCP create_test_plan tool with plain text data
+5. Provide HTML source for user to copy to web interface manually
+
+## Expected User Input Format:
+User should provide:
+- Project Name (e.g., "User Session Management")
+- Test Plan Name
+- Test Plan Description/Notes (optional)
+- Active Status (optional, defaults to active)
+- Public Status (optional, defaults to public)
+
+## Agent Processing Steps:
+1. **Validate Input**: Check for required fields (project name, test plan name)
+2. **Use Plain Text**: Send description/notes as plain text (no HTML formatting)
+3. **Call API**: Use create_test_plan tool with plain text data
+4. **Verify Creation**: Confirm test plan was created successfully
+5. **Provide HTML Source**: Give user HTML code to copy to web interface manually
+
+## Example Usage:
+**User Input:**
+```
+Create test plan for project "User Session Management"
+Name: Session Management Validation Test Plan
+Description: Comprehensive test plan for validating session management functionality
+Scope:
+- user profile configuration with session limits (1-1000)
+- UI validation and boundary testing
+- Configuration persistence and data integrity
+- API functionality and error handling
+```
+
+**Agent Processing:**
+1. Extract: projectName="User Session Management", name="Session Management Validation Test Plan", etc.
+2. Use plain text: "Comprehensive test plan for validating session management functionality. Scope: user profile configuration with session limits (1-1000), UI validation and boundary testing, Configuration persistence and data integrity, API functionality and error handling."
+3. Call: create_test_plan with plain text data
+4. Verify: Check creation was successful
+5. Provide HTML source for manual copy to web interface
+
+**API Notes:**
+- Must use exact project name, not project prefix (e.g., "User Session Management" not "USM")
+- Project name must match exactly as shown in list_projects output
+- Test plan will be created in the specified project
+- ⚠️ **IMPORTANT**: Use PLAIN TEXT only - no HTML formatting in API calls
+- ⚠️ **LIMITATION**: TestLink XML-RPC API does NOT support HTML formatting for test plans
+
+## Manual HTML Formatting (for Web Interface):
+If user wants rich formatting, provide HTML source for manual copy to TestLink web interface:
+
+**HTML Template:**
+```html
+<h3>Test Plan Overview</h3>
+<p>Brief description of the test plan purpose and scope.</p>
+
+<h4>Scope</h4>
+<ul>
+<li>First area of testing</li>
+<li>Second area of testing</li>
+<li>Third area of testing</li>
+</ul>
+
+<h4>Test Strategy</h4>
+<p>Description of the overall testing approach and methodology.</p>
+
+<h4>Success Criteria</h4>
+<ul>
+<li>First success criterion</li>
+<li>Second success criterion</li>
+</ul>
+```
+
+**Instructions for User:**
+1. Create test plan via API (plain text)
+2. Open TestLink web interface
+3. Navigate to Test Plan Management
+4. Edit the created test plan
+5. Copy HTML source above into the Description field
+6. Save changes
+
+## Plain Text Formatting (for API):
+Use simple, clear descriptions without HTML:
+
+**Plain Text Examples:**
+- Simple description: "Comprehensive test plan for validating session management functionality"
+- Structured description: "Test Plan Overview: Brief description. Scope: First area, Second area, Third area. Test Strategy: Description of approach. Success Criteria: First criterion, Second criterion."
+- Technical details: "Test plan for Session Management feature with token rotation support"
+
+Required Create Fields:
+- project_id: String (exact project name, not prefix)
+- name: String (test plan name)
+- notes: String (plain text description, optional)
+- active: Integer (1 = active, 0 = inactive, optional, defaults to 1)
+- is_public: Integer (1 = public, 0 = private, optional, defaults to 1)
+
+Best Practices:
+✅ Use exact project name from list_projects output
+✅ Use plain text descriptions (no HTML formatting)
+✅ Keep descriptions clear and comprehensive
+✅ Always verify creation was successful
+✅ Use descriptive test plan names with clear purpose
+✅ Provide HTML source for manual web interface formatting if needed
+
+Common Issues & Solutions:
+❌ "Test Project (name:XXX) does not exist" → Use exact project name from list_projects, not prefix
+❌ "Missing required fields" → Ensure project_id and name are provided
+❌ "Project ID must contain only digits" → Use project name, not numeric ID
+❌ Test plan not appearing → Verify project name matches exactly
+❌ User wants HTML formatting → Provide HTML source for manual copy to web interface
+
+Project Name Examples:
+✅ Correct: "User Session Management"
+❌ Incorrect: "USM" (this is the prefix)
+❌ Incorrect: "1" (this is the numeric ID)
+
+Test Plan Naming Conventions:
+✅ "AIGEN - [Feature] Test Plan" for AI-generated test plans
+✅ "Manual - [Feature] Validation" for manual testing focus
+✅ "Automated - [Feature] Regression" for automated testing
+✅ "Integration - [System] Testing" for integration testing
+
+## ⚠️ Important: No HTML Formatting in API Calls
+
+**TestLink XML-RPC API Limitation:**
+- Test plan `notes` field only supports plain text
+- HTML formatting will be stored as encoded text and display as raw code
+- Use plain text descriptions only in API calls
+
+**For Rich Formatting:**
+- Create test plan via API with plain text
+- Provide HTML source for user to copy manually to web interface
+- Web interface supports full HTML rendering
+
+## Agent Response Template:
+
+**When creating test plan:**
+```
+Test plan created successfully!
+
+Test Plan Details:
+- ID: [plan_id]
+- Name: [test_plan_name]
+- Project: [project_name]
+- Status: Active and Public
+
+For rich HTML formatting, copy this HTML source to the TestLink web interface:
+
+[HTML_SOURCE_HERE]
+
+Instructions:
+1. Open TestLink web interface
+2. Navigate to Test Plan Management
+3. Edit the created test plan
+4. Copy the HTML source above into the Description field
+5. Save changes
+```

--- a/.claude/commands/testlink/tl-create-suite.md
+++ b/.claude/commands/testlink/tl-create-suite.md
@@ -1,0 +1,92 @@
+# Create TestLink Test Suite
+
+```
+Create new test suite in TestLink with HTML formatting support for details.
+
+## Agent Instructions:
+1. Extract test suite data from user input
+2. Apply HTML formatting to details field if needed
+3. Generate external ID automatically or use provided format
+4. Call TestLink MCP create_test_suite tool with formatted data
+5. Return new suite ID and confirmation
+
+## Expected User Input:
+User should provide:
+- Project ID (where to create the test suite)
+- Test Suite Name
+- Suite Details/Description (optional, supports HTML formatting)
+- Parent Suite ID (optional, for nested suites)
+
+## Agent Processing Steps:
+1. **Validate Input**: Check for required fields (project ID, suite name)
+2. **Format Details**: Apply HTML formatting if details contain special characters
+3. **Prepare Data**: Structure data for MCP tool call
+4. **Call API**: Use create_test_suite tool with formatted data
+5. **Return Result**: Provide new suite ID and creation confirmation
+
+## Example Usage:
+**User Input:**
+```
+Create test suite in project 1
+Name: User Session Management Suite
+Details: Comprehensive test suite for validating session management functionality with token rotation support. Includes GUI testing, automation testing, and customer scenario replication.
+```
+
+**Agent Processing:**
+1. Extract: projectId="1", name="User Session Management Suite", details="..."
+2. Format details: Apply HTML formatting for special characters
+3. Prepare data: Structure for MCP tool
+4. Call: create_test_suite with formatted data
+5. Return: New suite ID and creation confirmation
+
+**Formatted Output:**
+```
+Suite Created Successfully!
+Suite ID: 12
+Name: User Session Management Suite
+Details: <p>Comprehensive test suite for validating session management functionality with token rotation support. Includes GUI testing, automation testing, and customer scenario replication.</p>
+```
+
+## HTML Formatting:
+- Apply formatting per `/tl-format` rules (details field uses summary formatting conventions)
+
+## MCP Tool Parameters:
+```json
+{
+  "project_id": "string (required)",
+  "suite_name": "string (required)",
+  "details": "string (optional, HTML formatted)",
+  "parent_id": "string (optional)"
+}
+```
+
+## Required Fields:
+- project_id: String (project ID where suite will be created)
+- suite_name: String (name of the new test suite)
+
+## Optional Fields:
+- details: String (test suite description, HTML formatted)
+- parent_id: String (parent suite ID for nested suites)
+
+## Success Criteria:
+✅ Project ID and suite name provided
+✅ Data properly formatted for MCP tool
+✅ HTML formatting applied to details if needed
+✅ Suite creation completed successfully
+✅ New suite ID returned to user
+
+## Common Scenarios:
+- "Create Authentication test suite in project 1"
+- "Create UI test suite in project 490671 with details 'User interface testing'"
+- "Create nested API test suite under parent suite 5"
+- "Create test suite with HTML formatted details"
+
+## Nested Suite Creation:
+For nested suites, provide parent_id:
+```
+Create test suite in project 1
+Name: API Testing Suite
+Parent Suite ID: 5
+Details: Nested suite for API endpoint testing
+```
+```

--- a/.claude/commands/testlink/tl-execute-case.md
+++ b/.claude/commands/testlink/tl-execute-case.md
@@ -1,0 +1,344 @@
+# Execute Test Case with Browser Automation
+
+```
+Execute test case from TestLink using browser MCP tools to perform automated testing and verify feature functionality.
+
+## Agent Instructions:
+1. Read test case from TestLink using test case ID
+2. Navigate to the application URL
+3. Perform login if credentials provided
+4. Execute each test step sequentially using browser MCP tools
+5. Verify expected results at each step
+6. Document test execution results
+7. Determine if feature meets test objective
+
+## Expected User Input Format:
+User should provide:
+- Test Case ID (external format like "TC-001" or numeric)
+- Application URL (e.g., "app.example.com")
+- Login credentials (optional):
+  - Email/Username
+  - Password
+- Any additional context or requirements
+
+## Agent Processing Steps:
+1. **Read Test Case**: Get test case details from TestLink
+2. **Browser Setup**: Navigate to application URL, resize if needed
+3. **Authentication**: Login if credentials provided
+4. **Execute Steps**: Follow each test step sequentially
+5. **Verify Results**: Check expected results match actual results
+6. **Document Outcomes**: Record pass/fail status for each step
+7. **Final Assessment**: Determine if feature meets test objective
+
+## Browser MCP Tools Available:
+- `playwright-mcp:browser_navigate` - Navigate to URL
+- `playwright-mcp:browser_snapshot` - Capture page state/structure
+- `playwright-mcp:browser_click` - Click buttons/elements
+- `playwright-mcp:browser_type` - Enter text in fields
+- `playwright-mcp:browser_select_option` - Select dropdown options
+- `playwright-mcp:browser_hover` - Hover over elements
+- `playwright-mcp:browser_press_key` - Press keyboard keys
+- `playwright-mcp:browser_wait_for` - Wait for text/elements/time
+- `playwright-mcp:browser_resize` - Resize browser window
+- `playwright-mcp:browser_take_screenshot` - Capture screenshots
+- `playwright-mcp:browser_console_messages` - Get console messages
+- `playwright-mcp:browser_network_requests` - Get network requests
+
+## Example Usage:
+**User Input:**
+```
+Execute test case TC-001
+URL: app.example.com
+Credentials: user@example.com / your-password
+```
+
+**Agent Processing:**
+1. Read test case TC-001 from TestLink
+2. Navigate to https://app.example.com
+3. Login with provided credentials
+4. Follow all test steps from the test case
+5. Verify each expected result
+6. Document execution results
+
+## Step-by-Step Execution Workflow:
+
+### 1. Read Test Case from TestLink
+```
+- Use testlink-mcp:read_test_case with test case ID
+- Extract: name, summary, preconditions, steps
+- Understand test objective and expected behavior
+```
+
+### 2. Browser Initialization
+```
+- Navigate to application URL
+- Resize browser to minimum 1280px width if needed
+- Take initial snapshot to understand page structure
+- Wait for page to fully load
+```
+
+### 3. Authentication (if required)
+```
+- Locate login form elements
+- Enter credentials in appropriate fields
+- Click login/submit button
+- Wait for authentication to complete
+- Verify successful login (check for dashboard/main page)
+```
+
+### 4. Execute Test Steps
+For each test step:
+```
+- Read step action and expected result
+- Locate UI elements using snapshot references
+- Perform the action (click, type, select, etc.)
+- Wait for action to complete
+- Take snapshot to verify result
+- Compare actual result with expected result
+- Document pass/fail status
+```
+
+### 5. Element Interaction Patterns
+
+**Clicking Elements:**
+```
+- Use browser_snapshot to get element reference
+- Use browser_click with element ref
+- Wait for action to complete
+- Verify expected change occurred
+```
+
+**Typing Text:**
+```
+- Locate textbox/input field
+- Use browser_type with element ref and text
+- Verify text was entered correctly
+```
+
+**Selecting Options:**
+```
+- Locate dropdown/combobox
+- Use browser_select_option with element ref and values
+- Verify selection was applied
+```
+
+**Navigation:**
+```
+- Use browser_navigate for direct URL navigation
+- Or click navigation menu items
+- Verify correct page loaded
+```
+
+### 6. Verification Strategies
+
+**Verify Page Display:**
+```
+- Check URL matches expected path
+- Verify page title or heading
+- Confirm key elements are visible
+```
+
+**Verify Form Fields:**
+```
+- Check field values match expected input
+- Verify validation messages (if any)
+- Confirm field states (enabled/disabled)
+```
+
+**Verify Table/List Content:**
+```
+- Locate table/list in snapshot
+- Find target row/item
+- Verify column values match expected
+- Check for success indicators
+```
+
+**Verify Messages/Notifications:**
+```
+- Look for success/error notifications
+- Check for alert messages
+- Verify message text matches expected
+```
+
+## Best Practices:
+
+### Browser Setup:
+✅ Resize browser to at least 1280px width for optimal display
+✅ Wait for page loads between actions (2-3 seconds)
+✅ Take snapshots frequently to understand page state
+✅ Handle responsive design warnings gracefully
+
+### Element Interaction:
+✅ Always take snapshot before interacting with elements
+✅ Use element references (ref) from snapshots for reliable interaction
+✅ Wait for elements to be ready before interaction
+✅ Verify actions completed successfully
+
+### Error Handling:
+✅ Check for validation errors after form input
+✅ Handle page load timeouts gracefully
+✅ Verify element exists before interaction
+✅ Document any unexpected behaviors
+
+### Test Execution:
+✅ Execute steps in sequential order
+✅ Verify each step before proceeding to next
+✅ Document actual vs expected results
+✅ Capture screenshots at key verification points
+✅ Note any discrepancies or issues
+
+### Credentials Management:
+✅ Use provided credentials securely
+✅ Clear sensitive data from logs if needed
+✅ Handle authentication failures gracefully
+
+## Common Issues & Solutions:
+
+### ❌ "Screen width too low" warning
+**Cause**: Browser window too narrow
+**Solution**: Use browser_resize to set width to 1280px or higher
+
+### ❌ Element not found in snapshot
+**Cause**: Page not fully loaded or element not visible
+**Solution**: 
+- Wait for page to load (browser_wait_for)
+- Take new snapshot
+- Check if element is in different location
+
+### ❌ Form validation errors
+**Cause**: Invalid input or missing required fields
+**Solution**:
+- Check field requirements
+- Verify input format
+- Clear and re-enter correct values
+
+### ❌ Login fails
+**Cause**: Invalid credentials or authentication issue
+**Solution**:
+- Verify credentials are correct
+- Check for error messages
+- Try navigating directly to login page
+
+### ❌ Page navigation doesn't work
+**Cause**: Element not clickable or page not ready
+**Solution**:
+- Wait for page to be interactive
+- Try alternative navigation method
+- Check for JavaScript errors in console
+
+### ❌ Expected result doesn't match
+**Cause**: Feature bug or test case mismatch
+**Solution**:
+- Document the discrepancy
+- Take screenshot for evidence
+- Continue with remaining steps
+- Note in final assessment
+
+## Test Execution Documentation:
+
+### Step-by-Step Results:
+For each step, document:
+- Step number and action
+- Actual result observed
+- Expected result from test case
+- Pass/Fail status
+- Screenshots (if applicable)
+- Notes or issues
+
+### Final Test Summary:
+```
+Test Case: [Test Case ID] - [Test Case Name]
+Test Objective: [Summary from test case]
+Execution Date: [Date/Time]
+Environment: [URL/Environment]
+
+Test Steps Executed: [X] of [Total]
+Steps Passed: [X]
+Steps Failed: [X]
+Steps Blocked: [X]
+
+Overall Result: PASS / FAIL / BLOCKED
+
+Key Findings:
+- [Finding 1]
+- [Finding 2]
+
+Issues/Discrepancies:
+- [Issue 1]
+- [Issue 2]
+
+Conclusion:
+[Does the feature meet the test objective?]
+```
+
+## Agent Response Template:
+
+**When starting execution:**
+```
+Starting test execution for [Test Case ID]: [Test Case Name]
+
+Test Objective: [Summary]
+Total Steps: [Number]
+
+Navigating to [URL]...
+```
+
+**During execution:**
+```
+Step [X]: [Action]
+✓ Expected: [Expected Result]
+✓ Actual: [Actual Result]
+Status: PASS / FAIL
+```
+
+**When execution completes:**
+```
+Test execution completed!
+
+Summary:
+- Total Steps: [X]
+- Passed: [X]
+- Failed: [X]
+- Overall Result: PASS / FAIL
+
+The feature [meets/does not meet] the test objective.
+```
+
+## Integration with TestLink:
+
+After execution, you may want to:
+- Create test execution record in TestLink
+- Update test case with findings
+- Create bug reports for failures
+- Document test results for reporting
+
+Use related commands:
+- `/tl-create-execution` - Record execution in TestLink
+- `/pm-bug-report` - Create bug reports for failures
+- `/tl-update-case` - Update test case with findings
+
+## Advanced Techniques:
+
+### Handling Dynamic Content:
+- Use browser_wait_for to wait for specific text
+- Take multiple snapshots to track changes
+- Use network requests to verify API calls
+
+### Debugging:
+- Use browser_console_messages to check for errors
+- Use browser_network_requests to verify API calls
+- Take screenshots at each step for troubleshooting
+
+### Performance Testing:
+- Monitor page load times
+- Check for slow network requests
+- Document performance observations
+
+## Notes:
+- Always verify test case steps are clear before execution
+- Document any ambiguities in test steps
+- Take screenshots for evidence of pass/fail
+- Be thorough in verification - don't skip expected results
+- If test fails, document exact failure point and behavior
+```
+

--- a/.claude/commands/testlink/tl-format.md
+++ b/.claude/commands/testlink/tl-format.md
@@ -1,0 +1,121 @@
+# TestLink Format
+
+```
+Format text for TestLink with proper HTML formatting and external ID format.
+
+## Agent Instructions:
+1. Take user input text and apply TestLink HTML formatting
+2. Convert plain text to proper HTML format according to guidelines below
+3. Apply HTML entities for special characters
+4. Return formatted text ready for TestLink use
+
+## Expected User Input:
+User provides plain text that needs TestLink formatting:
+- Test case summaries
+- Preconditions lists
+- Test step actions and expected results
+- Any text content for TestLink
+
+## Agent Processing Steps:
+1. **Identify Content Type**: Determine if input is summary, preconditions, actions, or expected results
+2. **Apply HTML Tags**: Wrap content in appropriate HTML tags
+3. **Format Lists**: Convert bullet points to <ul><li> or <ol><li> format
+4. **Apply Emphasis**: Use <strong> for important actions, <em> for alternatives
+5. **Convert Entities**: Replace >, <, ", &, ' with HTML entities
+6. **Validate Format**: Ensure proper HTML structure
+7. **Return Result**: Provide formatted HTML text
+
+## Example Usage:
+**User Input:**
+```
+Format this for TestLink:
+Summary: Verify user can login with valid credentials
+Preconditions:
+- Valid user account exists
+- Login page is accessible
+Steps:
+1. Navigate to login page
+2. Enter username and password
+3. Click Login button
+Expected: User successfully logs in and redirected to dashboard
+```
+
+**Agent Processing:**
+1. Identify: Summary, preconditions list, numbered steps, expected results
+2. Format summary: "<p>Verify user can <strong>login</strong> with valid credentials</p>"
+3. Format preconditions: "<ul><li>Valid user account exists</li><li>Login page is accessible</li></ul>"
+4. Format steps: Apply <p> tags and <strong> for actions
+5. Format expected: "<p>User successfully logs in and redirected to dashboard</p>"
+6. Apply entities: Convert any special characters
+7. Return: Complete HTML formatted text
+
+**Formatted Output:**
+```
+Summary: <p>Verify user can <strong>login</strong> with valid credentials</p>
+Preconditions: <ul><li>Valid user account exists</li><li>Login page is accessible</li></ul>
+Steps:
+1. <p>Navigate to login page</p>
+2. <p>Enter username and password</p>
+3. <p>Click <strong>Login</strong> button</p>
+Expected: <p>User successfully logs in and redirected to dashboard</p>
+```
+
+## HTML Formatting Rules:
+
+### Summary Formatting:
+- Wrap in <p> tags
+- Use <strong> for key actions and important terms
+- Example: "<p>Verify that users can <strong>perform action</strong> and validate behavior</p>"
+
+### Preconditions Formatting:
+- Convert bullet points to <ul><li> lists
+- Each item in separate <li> tag
+- Example: "<ul><li>Admin access with Advanced Permissions &gt; Feature &gt; Setting</li><li>Required configuration: Parameter &quot;value&quot;</li></ul>"
+
+### Actions Formatting:
+- Main action in <p> tags
+- Use <strong> for buttons, menus, field names
+- Use <em> for alternatives or clarifications
+- Sub-steps in <ul><li> or <ol><li> format
+- Example: "<p>Click button and click &quot;<strong>Edit</strong>&quot;</p><ul><li>Alternatively, click name then click &quot;<strong>Configure</strong>&quot;</li></ul>"
+
+### Expected Results Formatting:
+- Simple results: Use <br>• for multi-line items
+- Complex results: Use <p> with <ul><li> for validation lists
+- Example: "User can perform action successfully<br>• First validation point<br>• Second validation point"
+
+## HTML Entities Required:
+- &gt; for >, &lt; for <, &quot; for ", &amp; for &, &apos; for ', &nbsp; for non-breaking space
+
+## HTML Tags Available:
+- <p> for paragraphs
+- <strong> for bold/important text
+- <em> for italic/alternative text
+- <strong><em> for bold italic/critical emphasis
+- <ul><li> for bullet lists
+- <ol><li> for numbered lists
+- <br> for line breaks
+
+## Required Step Fields (for complete test cases):
+- step_number: String (e.g., "1", "2", "3")
+- actions: String (what to do, HTML formatted)
+- expected_results: String (what should happen, HTML formatted)
+- active: Integer (always use 1)
+- execution_type: Integer (1 = manual, 2 = automated)
+
+## Common Mistakes to Avoid:
+❌ Don't use \n for line breaks (shows as literal 'n')
+❌ Don't forget HTML entities for special characters
+❌ Don't use numeric-only external IDs
+❌ Don't skip required step fields
+❌ Don't mix HTML and plain text formatting
+
+## Success Criteria:
+✅ All text properly wrapped in HTML tags
+✅ Preconditions use <ul><li> HTML format
+✅ Multi-line expected results use <br>• format
+✅ All special characters use HTML entities
+✅ All required step fields included (if applicable)
+✅ All formatting follows HTML standards
+✅ Text is ready for direct use in TestLink
+```

--- a/.claude/commands/testlink/tl-get-case.md
+++ b/.claude/commands/testlink/tl-get-case.md
@@ -1,0 +1,100 @@
+# Get TestLink Test Case
+
+```
+Retrieve and display a specific test case from TestLink in a readable format.
+
+## Agent Instructions:
+1. Extract test case ID from user input
+2. Call TestLink MCP get_test_case tool with test case ID
+3. Format test case information in readable markdown format
+4. Display test case details including steps, preconditions, and summary
+
+## Expected User Input:
+User should provide:
+- Test Case ID (external format like "PROJ-1" or numeric ID)
+
+## Agent Processing Steps:
+1. **Extract Test Case ID**: Get test case ID from user input
+2. **Call API**: Use get_test_case MCP tool with test case ID
+3. **Format Data**: Organize test case information for display
+4. **Present Results**: Show test case in readable markdown format
+
+## Example Usage:
+**User Input:**
+```
+Get test case USM-1
+```
+
+**Agent Processing:**
+1. Extract: testCaseId="USM-1"
+2. Call: get_test_case with test_case_id="USM-1"
+3. Format: Organize test case data into markdown
+4. Present: Display formatted test case
+
+**Formatted Output:**
+```
+# Test Case: USM-1
+
+## Test Case Information
+- **ID**: USM-1
+- **Name**: [GUI] TC-PROJ-12345-001: Session Management Functional Validation
+- **Status**: Final
+- **Importance**: High
+- **Execution Type**: Manual
+
+## Summary
+Validate complete session management functionality including user profile configuration (1-1000 sessions), UI input field validation with boundary testing, and configuration persistence across save/load operations.
+
+## Pre-conditions
+- Cloud management platform configured and operational
+- Administrative access to cloud management interface
+- Browser automation framework (Playwright) configured
+
+## Test Steps
+| Step | Actions | Expected Results |
+|------|---------|------------------|
+| 1 | Navigate: Settings > Network Profiles > Add Profile | Navigation successful |
+| 2 | Configure: Profile Name > Authentication > Self Sign In > Email Token | Basic configuration complete |
+| 3 | Access: Show more settings > Session Limits tab | Session limit control visible |
+| 4 | Validate: Session limit spinbutton control exists and is functional | Control responsive and accessible |
+| 5 | Test minimum value: Set session limit to 1 | Value accepted, UI updates correctly |
+| 6 | Test maximum value: Set session limit to 1000 | Value accepted, UI updates correctly |
+```
+
+## MCP Tool Parameters:
+```json
+{
+  "test_case_id": "string (required)"
+}
+```
+
+## Required Fields:
+- test_case_id: String (test case ID to retrieve)
+
+## Display Format:
+- **Markdown Format**: Organized markdown with clear headings
+- **Table Format**: Test steps in organized table
+- **Key Details**: Test case ID, name, summary, preconditions, steps
+
+## Information Displayed:
+- Test Case ID and Name
+- Test Case Status and Importance
+- Summary/Test Objective
+- Pre-conditions (if any)
+- Test Steps in table format with Actions and Expected Results
+- Additional metadata (if available)
+
+## Success Criteria:
+✅ Test case ID extracted from user input
+✅ Test case retrieved successfully from TestLink
+✅ Information formatted in readable markdown
+✅ Test steps clearly organized in table format
+✅ User can easily understand test case content
+
+## Common Scenarios:
+- "Get test case USM-1"
+- "Show me test case 123"
+- "Display test case PROJ-5"
+- "Retrieve test case details for USM-2"
+- "Get test case information"
+```

--- a/.claude/commands/testlink/tl-get-cases-for-plan.md
+++ b/.claude/commands/testlink/tl-get-cases-for-plan.md
@@ -1,0 +1,227 @@
+# Get Test Cases for Test Plan
+
+```
+Get all test cases assigned to a TestLink test plan with proper output interpretation and guidance.
+
+## Agent Instructions:
+1. Extract test plan ID from user input
+2. Validate test plan exists before querying
+3. Call TestLink MCP get_test_cases_for_test_plan tool
+4. Interpret and present results in user-friendly format
+5. Provide guidance on using the test case data
+
+## Expected User Input Format:
+User should provide:
+- Test Plan ID (numeric)
+
+## Agent Processing Steps:
+1. **Validate Input**: Check for required field (plan_id)
+2. **Validate Plan**: Verify test plan exists
+3. **Call API**: Use get_test_cases_for_test_plan tool
+4. **Interpret Results**: Parse and format test case data
+5. **Present Data**: Show results in organized format
+
+## Example Usage:
+**User Input:**
+```
+Get test cases for test plan 10
+```
+
+**Agent Processing:**
+1. Extract: plan_id="10"
+2. Validate: Check test plan exists
+3. Call: get_test_cases_for_test_plan with plan_id
+4. Interpret: Parse test case assignment data
+5. Present: Show organized list with execution information
+
+**API Notes:**
+- Returns test cases assigned to the test plan
+- Includes execution status and metadata
+- Shows test case versions and execution details
+- Provides platform and urgency information
+
+## Output Data Interpretation:
+
+### **Test Plan Test Case Object Structure:**
+```json
+{
+  "13": [                    // Test case ID as key
+    {
+      "tcase_name": "Test Case Name",
+      "tcase_id": "13",      // Internal test case ID
+      "tc_id": "13",         // Test case ID (same as above)
+      "tcversion_id": "14",  // Test case version ID
+      "version": "1",        // Version number
+      "external_id": "1",    // Numeric part of external ID
+      "execution_type": "2", // Execution type (1=manual, 2=automated)
+      "status": "7",         // Test case status (7=final)
+      "feature_id": "1",     // Feature/assignment ID
+      "platform_id": "0",    // Platform ID (0=no platform)
+      "platform_name": "",   // Platform name
+      "execution_order": "1", // Execution order
+      "exec_status": "n",    // Execution status (n=not executed)
+      "execution_duration": "", // Execution duration
+      "full_external_id": "PROJ-1", // Full external ID
+      "exec_id": "0",        // Execution ID (0=no execution)
+      "tcversion_number": "", // Version number
+      "exec_on_build": "",   // Execution build
+      "exec_on_tplan": ""    // Execution test plan
+    }
+  ]
+}
+```
+
+### **Execution Status Values:**
+- **n** = Not executed
+- **p** = Passed
+- **f** = Failed
+- **b** = Blocked
+
+### **Execution Types:**
+- **1** = Manual execution
+- **2** = Automated execution
+
+### **Test Case Status:**
+- **7** = Final (ready for execution)
+- **1** = Draft
+
+## Common Errors & Solutions:
+
+### ❌ "Test plan not found"
+**Cause**: Invalid test plan ID or test plan doesn't exist
+**Solution**: Verify test plan exists using list_test_plans
+
+### ❌ "Missing required fields"
+**Cause**: Missing plan_id parameter
+**Solution**: Ensure plan_id is provided
+
+### ❌ "No test cases assigned"
+**Cause**: Test plan has no test cases assigned
+**Solution**: Use add_test_case_to_test_plan to assign test cases
+
+## Required Fields:
+- plan_id: String (numeric test plan ID)
+
+## Step-by-Step Process:
+
+### 1. Validate Test Plan
+- Use list_test_plans to verify test plan exists
+- Confirm test plan is active and accessible
+- Check if test plan belongs to correct project
+
+### 2. Execute Query
+- Call get_test_cases_for_test_plan with validated plan_id
+- Handle any API errors gracefully
+- Verify results are returned
+
+### 3. Process Results
+- Parse test case assignment data
+- Extract key information (name, status, execution info)
+- Format results for user presentation
+
+### 4. Present Data
+- Show test cases in organized format
+- Highlight execution status and metadata
+- Provide guidance on next steps
+
+## Best Practices:
+✅ Always validate test plan exists before querying
+✅ Present test case data with execution information
+✅ Highlight execution status and progress
+✅ Show test case versions and metadata
+✅ Provide guidance on execution and management
+✅ Handle empty results gracefully
+
+## Data Presentation Examples:
+
+### **Simple List Format:**
+```
+Test Cases in Plan: [Plan Name]
+
+1. PROJ-1 - Test Case Name (Status: Not Executed)
+2. PROJ-2 - Another Test Case (Status: Passed)
+3. PROJ-3 - Third Test Case (Status: Failed)
+```
+
+### **Detailed Format:**
+```
+Test Cases in Plan: [Plan Name]
+
+PROJ-1 - Test Case Name
+├─ ID: 13
+├─ Version: 1
+├─ Execution Status: Not Executed (n)
+├─ Type: Manual (1)
+├─ Platform: None (0)
+├─ Execution Order: 1
+└─ Assignment ID: 1
+
+PROJ-2 - Another Test Case
+├─ ID: 27
+├─ Version: 1
+├─ Execution Status: Passed (p)
+├─ Type: Automated (2)
+├─ Platform: None (0)
+├─ Execution Order: 2
+└─ Assignment ID: 2
+```
+
+### **Execution Summary Format:**
+```
+Test Plan Execution Summary: [Plan Name]
+
+Total Test Cases: 4
+├─ Not Executed: 2
+├─ Passed: 1
+├─ Failed: 1
+└─ Blocked: 0
+
+Execution Progress: 50% (2/4 completed)
+```
+
+## Agent Response Template:
+
+**When query succeeds:**
+```
+Found [count] test cases in test plan: [plan_name]
+
+Test Cases:
+[Formatted list of test cases with execution information]
+
+Execution Summary:
+- Total: [total_count]
+- Not Executed: [not_executed_count]
+- Passed: [passed_count]
+- Failed: [failed_count]
+- Blocked: [blocked_count]
+
+Next Steps:
+- Use create_test_execution to record execution results
+- Use read_test_execution to get detailed execution info
+- Use add_test_case_to_test_plan to add more test cases
+```
+
+**When no test cases found:**
+```
+No test cases found in test plan: [plan_name]
+
+This means the test plan is empty and needs test cases assigned.
+
+Suggestions:
+- Use add_test_case_to_test_plan to assign test cases
+- Use list_test_cases_in_suite to find available test cases
+- Check if test cases are assigned to different test plans
+```
+
+**When handling errors:**
+```
+❌ Failed to get test cases: [error_message]
+
+Troubleshooting:
+1. Verify test plan ID is correct
+2. Check test plan exists using list_test_plans
+3. Ensure you have access to the test plan
+4. Verify test plan belongs to correct project
+
+Would you like me to help resolve this issue?
+```

--- a/.claude/commands/testlink/tl-identify-type.md
+++ b/.claude/commands/testlink/tl-identify-type.md
@@ -1,0 +1,238 @@
+# Identify TestLink Test Case Type
+
+```
+Identify test case type (GUI, API, or other) and add appropriate prefix based on content analysis.
+
+## Agent Instructions:
+1. Analyze test case content to determine test type (GUI, API, or other)
+2. Add appropriate prefix to test case name based on identified type
+3. Apply HTML formatting if needed
+4. Return test case with proper type prefix
+
+## Expected User Input:
+User provides test case data for type identification:
+- Test case name
+- Summary/Test Objective
+- Test steps with actions and expected results
+- Any additional test case content
+
+## Agent Processing Steps:
+1. **Analyze Content**: Review test case name, summary, and steps
+2. **Identify Test Type**: Determine if it's GUI, API, or other type
+3. **Apply Prefix**: Add appropriate prefix to test case name
+4. **Format Content**: Apply HTML formatting if needed
+5. **Return Result**: Provide test case with proper type prefix
+
+## Test Type Identification Rules:
+
+### [GUI] Prefix - UI Validation Tests:
+Apply when test case contains:
+- UI element interactions (buttons, menus, forms, fields)
+- Navigation between pages/screens
+- Visual validation or display checks
+- User interface testing
+- Browser-based operations
+- Click, type, select, hover actions
+- Page loading, rendering, responsiveness
+- Form validation, input fields, dropdowns
+- Modal dialogs, popups, alerts
+- Screen resolution, layout testing
+
+**Keywords to look for:**
+- "click", "navigate", "select", "type", "hover"
+- "button", "menu", "form", "field", "dropdown"
+- "page", "screen", "window", "dialog"
+- "display", "show", "render", "appear"
+- "UI", "interface", "browser", "web"
+
+### [API] Prefix - API Operation Tests:
+Apply when test case contains:
+- HTTP requests (GET, POST, PUT, DELETE)
+- API endpoints, URLs, endpoints
+- Request/response validation
+- Data exchange between systems
+- Backend service testing
+- Integration testing
+- Authentication tokens, headers
+- JSON/XML data handling
+- Status codes, error responses
+- Database operations via API
+
+**Keywords to look for:**
+- "API", "endpoint", "request", "response"
+- "HTTP", "GET", "POST", "PUT", "DELETE"
+- "JSON", "XML", "data", "payload"
+- "status code", "error", "success"
+- "token", "header", "authentication"
+- "service", "integration", "backend"
+
+### No Prefix - Other Tests:
+Leave unchanged when test case contains:
+- Business logic testing
+- Data validation
+- Performance testing
+- Security testing
+- Configuration testing
+- Environment setup
+- General functional testing
+- Non-UI, non-API operations
+
+## Example Usage:
+
+### GUI Test Case:
+**User Input:**
+```
+Name: Login Page Validation
+Summary: Verify user can login through the web interface
+Steps:
+1. Navigate to login page
+2. Enter username in username field
+3. Enter password in password field
+4. Click Login button
+5. Verify user is redirected to dashboard
+Expected: User successfully logs in and sees dashboard page
+```
+
+**Agent Processing:**
+1. Analyze: Contains "navigate", "click", "page", "field", "button"
+2. Identify: GUI/UI validation test
+3. Apply prefix: "[GUI] Login Page Validation"
+4. Format: Apply HTML formatting
+5. Return: Test case with [GUI] prefix
+
+**Output:**
+```
+Name: [GUI] Login Page Validation
+Summary: <p>Verify user can <strong>login</strong> through the web interface</p>
+Steps:
+1. <p>Navigate to login page</p>
+2. <p>Enter username in username field</p>
+3. <p>Enter password in password field</p>
+4. <p>Click <strong>Login</strong> button</p>
+5. <p>Verify user is redirected to dashboard</p>
+Expected: <p>User successfully logs in and sees dashboard page</p>
+```
+
+### API Test Case:
+**User Input:**
+```
+Name: User Authentication API
+Summary: Verify API returns correct response for user authentication
+Steps:
+1. Send POST request to /api/auth/login
+2. Include username and password in JSON payload
+3. Verify response status code is 200
+4. Validate response contains authentication token
+Expected: API returns success response with valid token
+```
+
+**Agent Processing:**
+1. Analyze: Contains "API", "POST request", "endpoint", "JSON", "status code"
+2. Identify: API operation test
+3. Apply prefix: "[API] User Authentication API"
+4. Format: Apply HTML formatting
+5. Return: Test case with [API] prefix
+
+**Output:**
+```
+Name: [API] User Authentication API
+Summary: <p>Verify API returns correct response for user authentication</p>
+Steps:
+1. <p>Send <strong>POST</strong> request to /api/auth/login</p>
+2. <p>Include username and password in <strong>JSON</strong> payload</p>
+3. <p>Verify response status code is <strong>200</strong></p>
+4. <p>Validate response contains authentication token</p>
+Expected: <p>API returns success response with valid token</p>
+```
+
+### Mixed Test Case:
+**User Input:**
+```
+Name: Data Validation Test
+Summary: Verify data integrity across the system
+Steps:
+1. Create test data in database
+2. Process data through business logic
+3. Validate data consistency
+4. Clean up test data
+Expected: Data maintains integrity throughout process
+```
+
+**Agent Processing:**
+1. Analyze: Contains "data", "database", "business logic", "validation"
+2. Identify: General functional test (not GUI or API specific)
+3. Apply prefix: No prefix (leave unchanged)
+4. Format: Apply HTML formatting
+5. Return: Test case without prefix
+
+**Output:**
+```
+Name: Data Validation Test
+Summary: <p>Verify data integrity across the system</p>
+Steps:
+1. <p>Create test data in database</p>
+2. <p>Process data through business logic</p>
+3. <p>Validate data consistency</p>
+4. <p>Clean up test data</p>
+Expected: <p>Data maintains integrity throughout process</p>
+```
+
+## Prefix Application Rules:
+
+### [GUI] Prefix Application:
+- **UI Interactions**: Any test involving user interface elements
+- **Navigation**: Page/screen navigation testing
+- **Visual Validation**: Display, rendering, layout testing
+- **Form Testing**: Input fields, buttons, dropdowns
+- **Browser Operations**: Web-based testing
+
+### [API] Prefix Application:
+- **HTTP Operations**: Any HTTP request/response testing
+- **Service Integration**: Backend service testing
+- **Data Exchange**: API-based data operations
+- **Authentication**: Token-based authentication testing
+- **Endpoint Testing**: Specific API endpoint validation
+
+### No Prefix (Leave Unchanged):
+- **Business Logic**: Core functionality testing
+- **Data Processing**: Data validation and manipulation
+- **Configuration**: System configuration testing
+- **Performance**: Performance and load testing
+- **Security**: Security testing (non-API)
+- **General Functional**: Broad functional testing
+
+## HTML Formatting Applied:
+- Summary: <p> tags with <strong> for emphasis
+- Actions: <p> tags with <strong> for UI elements and technical terms
+- Expected Results: <p> tags with <strong> for key outcomes
+- HTML Entities: &gt;, &lt;, &quot;, &amp;, &apos; for special characters
+
+## Success Criteria:
+✅ Test type correctly identified (GUI, API, or other)
+✅ Appropriate prefix applied based on test type
+✅ Test case name properly prefixed
+✅ Content formatted with appropriate HTML
+✅ All special characters use HTML entities
+✅ Test type clearly identified and categorized
+✅ Ready for TestLink use with proper type prefix
+
+## Common Scenarios:
+
+### GUI Test Examples:
+- "Login Page Testing" → "[GUI] Login Page Testing"
+- "Form Validation" → "[GUI] Form Validation"
+- "Navigation Testing" → "[GUI] Navigation Testing"
+- "Button Functionality" → "[GUI] Button Functionality"
+
+### API Test Examples:
+- "User API Testing" → "[API] User API Testing"
+- "Authentication Service" → "[API] Authentication Service"
+- "Data Endpoint Validation" → "[API] Data Endpoint Validation"
+- "HTTP Response Testing" → "[API] HTTP Response Testing"
+
+### No Prefix Examples:
+- "Data Validation" → "Data Validation" (unchanged)
+- "Performance Testing" → "Performance Testing" (unchanged)
+- "Security Testing" → "Security Testing" (unchanged)
+- "Configuration Testing" → "Configuration Testing" (unchanged)
+```

--- a/.claude/commands/testlink/tl-list-cases.md
+++ b/.claude/commands/testlink/tl-list-cases.md
@@ -1,0 +1,201 @@
+# List Test Cases in Test Suite
+
+```
+List all test cases in a TestLink test suite with proper output interpretation and guidance.
+
+## Agent Instructions:
+1. Extract test suite ID from user input
+2. Validate test suite exists before listing
+3. Call TestLink MCP list_test_cases_in_suite tool
+4. Interpret and present results in user-friendly format
+5. Provide guidance on using the test case data
+
+## Expected User Input Format:
+User should provide:
+- Test Suite ID (numeric)
+
+## Agent Processing Steps:
+1. **Validate Input**: Check for required field (suite_id)
+2. **Validate Suite**: Verify test suite exists
+3. **Call API**: Use list_test_cases_in_suite tool
+4. **Interpret Results**: Parse and format test case data
+5. **Present Data**: Show results in organized format
+
+## Example Usage:
+**User Input:**
+```
+List test cases in suite 12
+```
+
+**Agent Processing:**
+1. Extract: suite_id="12"
+2. Validate: Check suite exists
+3. Call: list_test_cases_in_suite with suite_id
+4. Interpret: Parse test case data and metadata
+5. Present: Show organized list with key information
+
+**API Notes:**
+- Returns array of test cases with detailed information
+- Includes external IDs, versions, status, and metadata
+- Shows test case hierarchy and relationships
+- Provides execution and design information
+
+## Output Data Interpretation:
+
+### **Test Case Object Structure:**
+```json
+{
+  "id": "13",                    // Internal test case ID
+  "external_id": "PROJ-1",       // External ID (PROJ-1)
+  "tc_external_id": "1",         // Numeric part of external ID
+  "name": "Test Case Name",      // Test case name
+  "version": "1",                // Version number
+  "status": "7",                 // Status (7=final, 1=draft)
+  "summary": "<p>Summary...</p>", // HTML formatted summary
+  "preconditions": "<ul>...</ul>", // HTML formatted preconditions
+  "importance": "2",             // Importance (1=low, 2=medium, 3=high)
+  "execution_type": "1",         // Execution type (1=manual, 2=automated)
+  "steps": [...]                 // Array of test steps
+}
+```
+
+### **Status Values:**
+- **1** = Draft
+- **7** = Final (ready for execution)
+
+### **Importance Levels:**
+- **1** = Low priority
+- **2** = Medium priority
+- **3** = High priority
+
+### **Execution Types:**
+- **1** = Manual execution
+- **2** = Automated execution
+
+## Common Errors & Solutions:
+
+### ❌ "ID 12 do not belongs to a Test Suite present on system"
+**Cause**: Invalid test suite ID or suite doesn't exist
+**Solution**: Verify test suite exists using list_test_suites
+
+### ❌ "Missing required fields"
+**Cause**: Missing suite_id parameter
+**Solution**: Ensure suite_id is provided
+
+### ❌ "Test suite not found"
+**Cause**: Test suite doesn't exist or is inaccessible
+**Solution**: Check test suite ID and permissions
+
+## Required Fields:
+- suite_id: String (numeric test suite ID)
+
+## Step-by-Step Process:
+
+### 1. Validate Test Suite
+- Use list_test_suites to verify test suite exists
+- Confirm test suite is accessible
+- Check if suite belongs to correct project
+
+### 2. Execute Listing
+- Call list_test_cases_in_suite with validated suite_id
+- Handle any API errors gracefully
+- Verify results are returned
+
+### 3. Process Results
+- Parse test case data and metadata
+- Extract key information (ID, name, status, etc.)
+- Format results for user presentation
+
+### 4. Present Data
+- Show test cases in organized format
+- Highlight important information
+- Provide guidance on next steps
+
+## Best Practices:
+✅ Always validate test suite exists before listing
+✅ Present test case data in organized, readable format
+✅ Highlight key information (external ID, status, importance)
+✅ Show test case hierarchy and relationships
+✅ Provide guidance on using the test case data
+✅ Handle empty results gracefully
+
+## Data Presentation Examples:
+
+### **Simple List Format:**
+```
+Test Cases in Suite: [Suite Name]
+
+1. PROJ-1 - Test Case Name (Status: Final, Priority: Medium)
+2. PROJ-2 - Another Test Case (Status: Draft, Priority: High)
+3. PROJ-3 - Third Test Case (Status: Final, Priority: Low)
+```
+
+### **Detailed Format:**
+```
+Test Cases in Suite: [Suite Name]
+
+PROJ-1 - Test Case Name
+├─ ID: 13
+├─ Status: Final (7)
+├─ Priority: Medium (2)
+├─ Type: Manual (1)
+├─ Version: 1
+└─ Summary: Brief description...
+
+PROJ-2 - Another Test Case
+├─ ID: 27
+├─ Status: Draft (1)
+├─ Priority: High (3)
+├─ Type: Automated (2)
+├─ Version: 1
+└─ Summary: Brief description...
+```
+
+## Agent Response Template:
+
+**When listing succeeds:**
+```
+Found [count] test cases in suite: [suite_name]
+
+Test Cases:
+[Formatted list of test cases with key information]
+
+Key Information:
+- External ID: Use for test case operations
+- Status: Final (7) = ready for execution, Draft (1) = in progress
+- Priority: High (3), Medium (2), Low (1)
+- Type: Manual (1) or Automated (2)
+
+Next Steps:
+- Use read_test_case to get detailed information
+- Use create_test_execution to record execution results
+- Use update_test_case to modify test case details
+```
+
+**When no test cases found:**
+```
+No test cases found in suite: [suite_name]
+
+This could mean:
+- Test suite is empty
+- Test cases are in nested suites
+- Test cases are in different status
+
+Suggestions:
+- Check nested test suites
+- Verify test case status filters
+- Use list_test_suites to explore structure
+```
+
+**When handling errors:**
+```
+❌ Failed to list test cases: [error_message]
+
+Troubleshooting:
+1. Verify test suite ID is correct
+2. Check test suite exists using list_test_suites
+3. Ensure you have access to the test suite
+4. Verify test suite belongs to correct project
+
+Would you like me to help resolve this issue?
+```

--- a/.claude/commands/testlink/tl-list-projects.md
+++ b/.claude/commands/testlink/tl-list-projects.md
@@ -1,0 +1,84 @@
+# List TestLink Projects
+
+```
+Retrieve and display all available test projects from TestLink.
+
+## Agent Instructions:
+1. Call TestLink MCP list_projects tool (no parameters required)
+2. Format project information in a readable format
+3. Display project details including ID, name, prefix, and status
+4. Present information in an organized, user-friendly manner
+
+## Expected User Input:
+User requests project information:
+- "Show me all available projects"
+- "List all TestLink projects"
+- "Display project information"
+- "What projects are available?"
+
+## Agent Processing Steps:
+1. **Call API**: Use list_projects MCP tool (no parameters needed)
+2. **Format Data**: Organize project information for display
+3. **Present Results**: Show project details in readable format
+4. **Highlight Key Info**: Emphasize important project details
+
+## Example Usage:
+**User Input:**
+```
+Show me all available projects
+```
+
+**Agent Processing:**
+1. Call: list_projects MCP tool
+2. Format: Organize project data
+3. Present: Display formatted project list
+
+**Formatted Output:**
+```
+Available TestLink Projects:
+┌─────────┬─────────────────────────────────┬─────────┬─────────┬─────────┐
+│   ID    │              Name               │ Prefix  │ Status  │ Active  │
+├─────────┼─────────────────────────────────┼─────────┼─────────┼─────────┤
+│    1    │ User Session Management         │  USM    │ Active  │   Yes   │
+│    2    │ Mobile App Testing              │  MAT    │ Active  │   Yes   │
+│    3    │ API Integration Tests           │  AIT    │ Active  │   Yes   │
+└─────────┴─────────────────────────────────┴─────────┴─────────┴─────────┘
+
+Project Details:
+• Project 1: User Session Management (USM) - Active
+• Project 2: Mobile App Testing (MAT) - Active  
+• Project 3: API Integration Tests (AIT) - Active
+```
+
+## MCP Tool Parameters:
+```json
+{}
+```
+*No parameters required - fetches all projects*
+
+## Display Format:
+- **Table Format**: Organized table with key project information
+- **Summary List**: Bullet points with project highlights
+- **Key Details**: Project ID, name, prefix, status, active status
+
+## Information Displayed:
+- Project ID
+- Project Name
+- Project Prefix (for external IDs)
+- Active Status
+- Project Status
+- Additional metadata (if available)
+
+## Success Criteria:
+✅ Projects retrieved successfully from TestLink
+✅ Information formatted in readable format
+✅ Key project details clearly displayed
+✅ User can easily identify available projects
+
+## Common Scenarios:
+- "Show me all available projects"
+- "List all TestLink projects"
+- "Display project information"
+- "What projects can I work with?"
+- "Show available test projects"
+```

--- a/.claude/commands/testlink/tl-list-requirements.md
+++ b/.claude/commands/testlink/tl-list-requirements.md
@@ -1,0 +1,85 @@
+# List TestLink Requirements
+
+```
+Retrieve and display all requirements for a specific TestLink project.
+
+## Agent Instructions:
+1. Extract project ID from user input
+2. Call TestLink MCP list_requirements tool with project ID
+3. Format requirements information in a readable format
+4. Display requirement details including ID, title, and description
+
+## Expected User Input:
+User should provide:
+- Project ID (to get requirements for)
+
+## Agent Processing Steps:
+1. **Extract Project ID**: Get project ID from user input
+2. **Call API**: Use list_requirements MCP tool with project ID
+3. **Format Data**: Organize requirements information for display
+4. **Present Results**: Show requirements in readable format
+
+## Example Usage:
+**User Input:**
+```
+Show requirements for project 1
+```
+
+**Agent Processing:**
+1. Extract: projectId="1"
+2. Call: list_requirements with project_id="1"
+3. Format: Organize requirements data
+4. Present: Display formatted requirements list
+
+**Formatted Output:**
+```
+Requirements for Project 1 (User Session Management):
+┌─────────┬─────────────────────────────────────────┬─────────────────────────┐
+│   ID    │                 Title                  │       Description       │
+├─────────┼─────────────────────────────────────────┼─────────────────────────┤
+│    6    │ BR-001: Token Rotation Session Limit    │ Session limit issue with│
+│         │ Issue                                   │ token rotation         │
+│    8    │ BR-002: Customer Issue Resolution      │ Resolution of customer  │
+│         │                                         │ session limit issues    │
+└─────────┴─────────────────────────────────────────┴─────────────────────────┘
+
+Requirement Details:
+• BR-001: Token Rotation Session Limit Issue
+• BR-002: Customer Issue Resolution
+```
+
+## MCP Tool Parameters:
+```json
+{
+  "project_id": "string (required)"
+}
+```
+
+## Required Fields:
+- project_id: String (project ID to get requirements for)
+
+## Display Format:
+- **Table Format**: Organized table with key requirements information
+- **Summary List**: Bullet points with requirements highlights
+- **Key Details**: Requirement ID, title, description
+
+## Information Displayed:
+- Requirement ID
+- Requirement Title
+- Requirement Description
+- Additional metadata (if available)
+
+## Success Criteria:
+✅ Project ID extracted from user input
+✅ Requirements retrieved successfully from TestLink
+✅ Information formatted in readable format
+✅ Key requirements details clearly displayed
+✅ User can easily identify available requirements
+
+## Common Scenarios:
+- "Show requirements for project 1"
+- "List requirements for Mobile App project"
+- "Get all requirements for project 1404789"
+- "What requirements are available in project 1?"
+- "Display requirements for User Session project"
+```

--- a/.claude/commands/testlink/tl-list-suites.md
+++ b/.claude/commands/testlink/tl-list-suites.md
@@ -1,0 +1,86 @@
+# List TestLink Test Suites
+
+```
+Retrieve and display all test suites for a specific TestLink project.
+
+## Agent Instructions:
+1. Extract project ID from user input
+2. Call TestLink MCP list_test_suites tool with project ID
+3. Format test suite information in a readable format
+4. Display suite details including ID, name, and description
+
+## Expected User Input:
+User should provide:
+- Project ID (to get test suites for)
+
+## Agent Processing Steps:
+1. **Extract Project ID**: Get project ID from user input
+2. **Call API**: Use list_test_suites MCP tool with project ID
+3. **Format Data**: Organize test suite information for display
+4. **Present Results**: Show test suites in readable format
+
+## Example Usage:
+**User Input:**
+```
+Show test suites for project 1
+```
+
+**Agent Processing:**
+1. Extract: projectId="1"
+2. Call: list_test_suites with project_id="1"
+3. Format: Organize test suite data
+4. Present: Display formatted test suite list
+
+**Formatted Output:**
+```
+Test Suites for Project 1 (User Session Management):
+┌─────────┬─────────────────────────────────────────┬─────────────────────────┐
+│   ID    │                 Name                    │       Description       │
+├─────────┼─────────────────────────────────────────┼─────────────────────────┤
+│   12    │ User Session Management - Essential     │ Essential test cases for│
+│         │ Test Cases                              │ session limit validation │
+│   13    │ GUI Testing Suite                       │ User interface testing  │
+│   14    │ API Testing Suite                       │ Backend service testing │
+└─────────┴─────────────────────────────────────────┴─────────────────────────┘
+
+Suite Details:
+• Suite 12: User Session Management - Essential Test Cases
+• Suite 13: GUI Testing Suite
+• Suite 14: API Testing Suite
+```
+
+## MCP Tool Parameters:
+```json
+{
+  "project_id": "string (required)"
+}
+```
+
+## Required Fields:
+- project_id: String (project ID to get test suites for)
+
+## Display Format:
+- **Table Format**: Organized table with key test suite information
+- **Summary List**: Bullet points with test suite highlights
+- **Key Details**: Suite ID, name, description
+
+## Information Displayed:
+- Test Suite ID
+- Test Suite Name
+- Test Suite Description
+- Additional metadata (if available)
+
+## Success Criteria:
+✅ Project ID extracted from user input
+✅ Test suites retrieved successfully from TestLink
+✅ Information formatted in readable format
+✅ Key test suite details clearly displayed
+✅ User can easily identify available test suites
+
+## Common Scenarios:
+- "Show test suites for project 1"
+- "List test suites for Mobile App project"
+- "Get all test suites for project 1404789"
+- "What test suites are available in project 1?"
+- "Display test suites for User Session project"
+```

--- a/.claude/commands/testlink/tl-read-execution.md
+++ b/.claude/commands/testlink/tl-read-execution.md
@@ -1,0 +1,231 @@
+# Read TestLink Test Execution
+
+```
+Read test execution details from TestLink with proper error handling and troubleshooting.
+
+## Agent Instructions:
+1. Extract test execution parameters from user input
+2. Understand the API limitation - requires test case ID
+3. Provide alternative approaches when direct reading fails
+4. Guide users to available workarounds
+5. Handle errors gracefully with clear explanations
+
+## Expected User Input Format:
+User should provide:
+- Test Plan ID (numeric)
+- Test Case ID (optional, but recommended for better results)
+- Build ID (optional, to filter by specific build)
+
+## Agent Processing Steps:
+1. **Validate Input**: Check for required fields (plan_id)
+2. **Explain Limitation**: Inform user about test case ID requirement
+3. **Provide Alternatives**: Suggest workarounds for reading executions
+4. **Attempt API Call**: Try read_test_execution with available parameters
+5. **Handle Errors**: Provide clear error messages and solutions
+
+## Example Usage:
+**User Input:**
+```
+Read test executions for test plan 10
+```
+
+**Agent Processing:**
+1. Extract: plan_id="10"
+2. Explain: API requires test case ID for best results
+3. Suggest: Use get_test_cases_for_test_plan first to get test cases
+4. Attempt: Call read_test_execution with plan_id only
+5. Handle: Provide error explanation and alternatives
+
+**API Notes:**
+- ⚠️ **LIMITATION**: TestLink API requires test case ID for reliable execution reading
+- Plan ID alone may not return all executions
+- Test case ID provides more accurate results
+- Build ID can filter executions by specific build
+
+## Common Errors & Solutions:
+
+### ❌ "Expected one of this fields: {["testcaseid","testcaseexternalid"]}"
+**Cause**: TestLink API requires test case ID for execution reading
+**Solution**: Use test case ID or alternative approach
+
+### ❌ "Test plan not found"
+**Cause**: Invalid test plan ID
+**Solution**: Verify test plan exists using list_test_plans
+
+### ❌ "No executions found"
+**Cause**: No test executions exist for the criteria
+**Solution**: Check if test cases are assigned and executed
+
+## Alternative Approaches:
+
+### 1. **Get Test Cases First (Recommended)**
+```
+1. Use get_test_cases_for_test_plan to get test cases in plan
+2. For each test case, use read_test_execution with test case ID
+3. Compile results for complete execution overview
+```
+
+### 2. **Use Test Case ID Directly**
+```
+1. Get test case ID from user or previous operations
+2. Use read_test_execution with both plan_id and test case ID
+3. Get specific execution details for that test case
+```
+
+### 3. **Check Build-Specific Executions**
+```
+1. Use list_builds to get available builds
+2. Use read_test_execution with plan_id and build_id
+3. Get executions for specific build
+```
+
+## Required Fields:
+- plan_id: String (test plan ID)
+
+## Optional Fields:
+- test_case_id: String (test case ID for better results)
+- build_id: String (build ID to filter executions)
+
+## Step-by-Step Process:
+
+### 1. Validate Test Plan
+- Use list_test_plans to verify test plan exists
+- Confirm test plan is active and accessible
+
+### 2. Choose Approach
+- **Option A**: Get test cases first, then read executions
+- **Option B**: Use provided test case ID directly
+- **Option C**: Read all executions (may have limitations)
+
+### 3. Execute Reading
+- Call read_test_execution with available parameters
+- Handle API limitations gracefully
+- Provide alternative suggestions if needed
+
+### 4. Process Results
+- Interpret execution data
+- Present results in user-friendly format
+- Highlight any limitations or missing data
+
+## Workaround Strategies:
+
+### **Strategy 1: Complete Execution Overview**
+```
+1. get_test_cases_for_test_plan(plan_id) → Get all test cases
+2. For each test case:
+   - read_test_execution(plan_id, test_case_id)
+3. Compile all execution results
+```
+
+### **Strategy 2: Build-Specific Executions**
+```
+1. list_builds(plan_id) → Get available builds
+2. For each build:
+   - read_test_execution(plan_id, build_id)
+3. Show executions by build
+```
+
+### **Strategy 3: Test Case Specific**
+```
+1. User provides specific test case ID
+2. read_test_execution(plan_id, test_case_id)
+3. Get detailed execution for that test case
+```
+
+## Test Case Object Structure:
+
+Response from get_test_cases_for_test_plan returns test cases keyed by ID:
+```json
+{
+  "13": [{
+    "tcase_name": "Test Case Name",
+    "tcase_id": "13",
+    "tcversion_id": "14",
+    "version": "1",
+    "full_external_id": "PROJ-1",
+    "exec_status": "n",
+    "execution_type": "1",
+    "execution_order": "1"
+  }]
+}
+```
+
+## Execution Type Values:
+- **1** = Manual execution
+- **2** = Automated execution
+
+## Execution Status Values:
+- **n** = Not executed
+- **p** = Passed
+- **f** = Failed
+- **b** = Blocked
+
+## Best Practices:
+✅ Always explain API limitations upfront
+✅ Provide alternative approaches when direct reading fails
+✅ Use test case ID when available for better results
+✅ Suggest getting test cases first for complete overview
+✅ Handle errors gracefully with clear explanations
+✅ Offer multiple strategies based on user needs
+
+## Error Handling Examples:
+
+**API Limitation Error:**
+```
+❌ Error: Expected one of this fields: {["testcaseid","testcaseexternalid"]}
+✅ Solution: Use test case ID or get test cases first
+```
+
+**No Executions Found:**
+```
+❌ Error: No executions found
+✅ Solution: Check if test cases are assigned and executed
+```
+
+## Agent Response Template:
+
+**When explaining limitation:**
+```
+⚠️ TestLink API Limitation: read_test_execution requires a test case ID for reliable results.
+
+Available Approaches:
+1. Get test cases first: get_test_cases_for_test_plan(plan_id)
+2. Use specific test case ID: read_test_execution(plan_id, test_case_id)
+3. Try with plan ID only (may have limitations)
+
+Which approach would you prefer?
+```
+
+**When providing alternatives:**
+```
+Since direct execution reading has limitations, here are your options:
+
+Option 1 - Complete Overview:
+1. Get all test cases in the plan
+2. Read executions for each test case
+3. Compile complete execution report
+
+Option 2 - Specific Test Case:
+1. Provide specific test case ID
+2. Read executions for that test case only
+
+Option 3 - Build-Specific:
+1. Get available builds
+2. Read executions by build
+
+Which option would you like me to execute?
+```
+
+**When execution succeeds:**
+```
+Test execution details retrieved successfully!
+
+Execution Summary:
+- Test Plan: [plan_name] (ID: [plan_id])
+- Test Case: [test_case_name] (ID: [test_case_id])
+- Build: [build_name] (ID: [build_id])
+- Status: [execution_status]
+- Notes: [execution_notes]
+
+[Additional execution details...]
+```

--- a/.claude/commands/testlink/tl-sync.md
+++ b/.claude/commands/testlink/tl-sync.md
@@ -1,0 +1,134 @@
+# Sync TestLink Test Cases
+
+Synchronize TestLink test cases with local test case files. This command automates the process of comparing, updating, and creating test cases in TestLink based on local markdown files.
+
+## When to Use
+
+- After creating or updating local test case files that need syncing to TestLink
+- Before test execution when TestLink must reflect the latest test cases
+
+## Usage
+
+When user provides:
+1. A TestLink test case ID (e.g., PROJ-12345)
+2. A local test case file path
+
+## Process
+
+### Step 1: Get Test Suite ID
+- Retrieve the specified test case from TestLink using the test case ID
+- Extract the test suite ID from the response
+- Confirm suite name and ID with the user
+
+### Step 2: List All Test Cases in Suite
+- Use the suite ID to get all test cases in the test suite
+- Display summary: total count and test case IDs
+
+### Step 3: Verify Mapping File IDs
+- If a `testlink_mapping.md` file exists in the project, verify that the TestLink IDs listed match the actual test case external IDs returned from Step 2
+- Flag any mismatches (wrong IDs, missing IDs) before proceeding
+- If mismatches are found, ask the user to confirm before continuing
+
+### Step 4: Compare with Local File
+- Read the local test case markdown file
+- Compare each test case from local file with TestLink:
+  - Check if test case exists in TestLink
+  - Compare: name, summary, preconditions, steps (actions and expected results)
+  - Track differences found
+  - **If test case matches completely (no differences):**
+    - Skip the test case - no update needed
+    - Add to "Test Cases Already Matching" list
+    - Do NOT call update API for matching test cases
+
+### Step 5: Update or Create Test Cases
+- **For existing test cases that match completely:**
+  - Skip update - preserve existing test case as-is
+  - Report as "already matching" in summary
+
+- **For existing test cases with differences:**
+  - **Version Backup**: Before updating, prompt the user: "Please create a new version for {Test Case ID} in TestLink before I update it." Wait for confirmation before proceeding.
+  - Update only the fields that differ
+  - Preserve test case IDs and version history
+  - Report what was updated
+
+- **For missing test cases (in local but not in TestLink):**
+  - Create new test cases with proper formatting
+  - Use HTML formatting according to TestLink format guidelines
+  - Apply proper importance level (1=High/P0, 2=Medium/P1, 3=Low/P2)
+  - Set execution_type to 1 (manual)
+  - Set status to 1 (final/ready)
+  - Report new test case IDs created
+
+### Step 6: Review Preconditions
+- After updates/creation, retrieve all test cases again
+- Check each test case for:
+  - Missing preconditions (empty string)
+  - Incorrect preconditions (not matching local file)
+- Fix any missing or incorrect preconditions
+- Report final status of all preconditions
+
+### Step 7: Final Verification (Optional)
+- Optionally review entire test case content:
+  - Summary formatting
+  - Step formatting
+  - HTML entities correctness
+  - Cross-references to other test cases
+
+## Output Format
+
+Provide structured summary:
+
+### Summary Report:
+- **Test Suite:** [Name] (ID: [suite_id])
+- **Total Test Cases in Local File:** X
+- **Total Test Cases in TestLink:** Y
+
+### Test Cases Already Matching: X
+- List test case IDs and names
+
+### Test Cases Updated: X
+- List test case IDs, names, and what was updated
+
+### New Test Cases Created: X
+- List new test case IDs and names
+
+### Preconditions Fixed: X
+- List test case IDs with precondition issues fixed
+
+### Final Status:
+✅ All X test cases synchronized successfully
+
+## Example Usage
+
+**User:** "Sync PROJ-12345 with [@03_TS-04_RESTful_API_Integration.md](file)"
+
+**Agent Response:**
+1. Retrieves PROJ-12345 to get suite ID 1234567
+2. Lists all test cases in suite (found 5 existing)
+3. Compares with local file (8 test cases total)
+4. Updates 2 test cases with precondition differences
+5. Creates 3 new test cases for Accounting profiles
+6. Reviews and fixes 3 missing preconditions
+7. Provides final summary report
+
+## Notes
+
+- Always use TestLink HTML format for content
+- Preserve existing test case properties when updating
+- Use proper HTML entities (&gt;, &lt;, &quot;, etc.)
+- Format preconditions as `<ul><li>` lists
+- Break down complex tasks into subtodos for tracking
+- Mark todos as completed immediately after finishing each step
+- Author login should be your TestLink username for new test cases
+- Project ID should match your TestLink project (use list_projects to find it)
+
+## TestLink Format
+
+See `/tl-format` for HTML formatting rules (preconditions, step actions, expected results, summaries, and entity encoding).
+
+## Error Handling
+
+- If test case ID not found, ask user to verify the ID
+- If local file not found, ask user to provide correct path
+- If preconditions field is returned as empty string from create operation, immediately update with correct preconditions
+- If API returns error, report the error and suggest resolution

--- a/.claude/commands/testlink/tl-update-case.md
+++ b/.claude/commands/testlink/tl-update-case.md
@@ -1,0 +1,86 @@
+# Update TestLink Test Case
+
+Update test case in TestLink with proper HTML formatting and TestLink compliance.
+
+## When to Use
+
+- After modifying local test case files that are already synced to TestLink
+- When test case summary, preconditions, or steps need updating in TestLink
+
+## Agent Instructions:
+1. Extract test case data from user input
+2. Apply HTML formatting according to guidelines below
+3. Use external ID format for updates (e.g., "PROJ-1", "ABC-12345")
+4. Call TestLink MCP update_test_case tool with formatted data
+
+## Expected User Input Format:
+User should provide:
+- Test Case ID (external format like "PROJ-1")
+- Test Case Name
+- Summary/Test Objective
+- Pre-conditions (optional)
+- Test Steps with Actions and Expected Results
+
+## Agent Processing Steps:
+1. **Version Backup**: Before updating, prompt the user: "Please create a new version for {Test Case ID} in TestLink before I update it." Wait for confirmation before proceeding.
+2. **Validate Input**: Check for required fields (ID, name, summary)
+3. **Format Summary**: Wrap in <p> tags, apply <strong> for emphasis
+4. **Format Preconditions**: Convert to <ul><li> list format
+5. **Format Steps**: Apply HTML formatting to actions and expected results
+6. **Apply HTML Entities**: Convert >, <, ", &, ' to proper entities
+7. **Call API**: Use update_test_case tool with formatted data
+
+## Example Usage:
+**User Input:**
+```
+Update test case PROJ-1
+Name: Login Validation Test
+Summary: Verify user can login with valid credentials
+Pre-conditions:
+- Valid user account exists
+- Login page is accessible
+Steps:
+1. Navigate to login page
+2. Enter valid username and password
+3. Click Login button
+Expected: User successfully logs in and redirected to dashboard
+```
+
+**Agent Processing:**
+1. Extract: ID="PROJ-1", name="Login Validation Test", etc.
+2. Format summary: "<p>Verify user can <strong>login</strong> with valid credentials</p>"
+3. Format preconditions: "<ul><li>Valid user account exists</li><li>Login page is accessible</li></ul>"
+4. Format steps with HTML entities and proper tags
+5. Call: update_test_case with formatted data
+
+**API Notes:**
+- If preconditions are missing after creation, use updateTestCase to add them
+- External ID format required for updates (not numeric IDs)
+- createTestCase may not process preconditions properly - update after creation
+
+HTML Formatting:
+- Apply formatting per `/tl-format` rules (summary, preconditions, actions, expected results, entities)
+
+Required Step Fields (handled automatically):
+- step_number: String or number ("1", "2", "3", etc.)
+- actions: String with proper HTML formatting
+- expected_results: String with proper HTML formatting
+- active: Integer (always 1 for active steps)
+- execution_type: Integer (1 = manual, 2 = automated)
+
+Best Practices:
+✅ Use <strong> for UI elements like buttons, menus, fields
+✅ Use <em> for alternatives or clarifications
+✅ Use <br>• for simple multi-line expected results
+✅ Use <ul><li> for complex validation lists
+✅ Apply HTML entities for all special characters
+✅ Keep actions clear and concise with proper formatting
+✅ Make expected results specific and measurable
+✅ Always verify updates were successful by reading the test case
+✅ Use external ID format for updates (e.g., "PROJ-1" not "13")
+✅ Update preconditions separately if missing after creation
+
+Common Issues & Solutions:
+❌ "Invalid XML-RPC message" → Use external ID format instead of numeric ID
+❌ Missing preconditions after creation → Use updateTestCase to add preconditions
+❌ HTML not rendering → Check HTML entity usage (&gt;, &lt;, &quot;, &apos;)

--- a/.claude/commands/testlink/tl-update-suite.md
+++ b/.claude/commands/testlink/tl-update-suite.md
@@ -1,0 +1,80 @@
+# Update TestLink Test Suite
+
+```
+Update existing test suite in TestLink with new properties and HTML formatting support.
+
+## Agent Instructions:
+1. Extract test suite data from user input
+2. Apply HTML formatting to details field if needed
+3. Use external ID format for updates (e.g., "PROJ-1", "ABC-12345")
+4. Call TestLink MCP update_test_suite tool with formatted data
+
+## Expected User Input:
+User should provide:
+- Test Suite ID (external format like "PROJ-1" or numeric ID)
+- New Suite Name (optional)
+- New Suite Details/Description (optional, supports HTML formatting)
+
+## Agent Processing Steps:
+1. **Validate Input**: Check for required fields (suite ID)
+2. **Format Details**: Apply HTML formatting if details contain special characters
+3. **Prepare Data**: Structure data for MCP tool call
+4. **Call API**: Use update_test_suite tool with formatted data
+5. **Return Result**: Provide update confirmation and new suite information
+
+## Example Usage:
+**User Input:**
+```
+Update test suite 12
+Name: Updated User Session Management Suite
+Details: Comprehensive test suite for validating session management functionality with token rotation support. Includes GUI testing, automation testing, and customer scenario replication.
+```
+
+**Agent Processing:**
+1. Extract: suiteId="12", name="Updated User Session Management Suite", details="..."
+2. Format details: Apply HTML formatting for special characters
+3. Prepare data: Structure for MCP tool
+4. Call: update_test_suite with formatted data
+5. Return: Update confirmation and suite information
+
+**Formatted Output:**
+```
+Suite ID: 12
+Name: Updated User Session Management Suite
+Details: <p>Comprehensive test suite for validating session management functionality with token rotation support. Includes GUI testing, automation testing, and customer scenario replication.</p>
+```
+
+## HTML Formatting:
+- Apply formatting per `/tl-format` rules (details field uses summary formatting conventions)
+
+## MCP Tool Parameters:
+```json
+{
+  "suite_id": "string (required)",
+  "data": {
+    "name": "string (optional)",
+    "details": "string (optional, HTML formatted)"
+  }
+}
+```
+
+## Required Fields:
+- suite_id: String (test suite ID to update)
+
+## Optional Fields:
+- name: String (new test suite name)
+- details: String (new test suite description, HTML formatted)
+
+## Success Criteria:
+✅ Suite ID provided and valid
+✅ Data properly formatted for MCP tool
+✅ HTML formatting applied to details if needed
+✅ Update operation completed successfully
+✅ Confirmation returned to user
+
+## Common Scenarios:
+- "Update suite 5 with new name 'Updated Authentication Suite'"
+- "Modify test suite 10 with new details"
+- "Update suite 15 name to 'API Testing Suite'"
+- "Change suite 20 details to include HTML formatting"
+```

--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -1,0 +1,72 @@
+---
+paths:
+  - "commands/dev-workflow/**/*.md"
+---
+
+# dev-workflow
+
+Turns a need into shipped code. A story states the **need** (a goal, not a spec); a
+**plan issue** states the agreed **approach**; task issues carry the *how* as it's worked
+out. Each producer is paired with a review — no producer ships without one.
+
+## The flow
+
+```
+   docs/stories/STORY-XXX.md
+            │
+   dw-story ───────► dw-review-story    the need — complete, and a goal not a spec
+            │
+            ▼
+   dw-plan ────────► [human reviews the plan issue]   research → ONE plan issue: the approach
+            │                                           (skip for trivial / single-task work)
+            ▼
+   dw-tasks ───────► dw-review-tasks    plan issue → task issues, each "Part of #<plan>"
+            │
+            ▼
+   dw-implement ───► dw-review-implement   build the issue; the plan issue is the
+            │                               checkpoint a fresh session resumes from
+            ▼
+   dw-create-pr ───► [human review + /review]   open the PR
+            │
+            ▼
+   dw-merge          green CI + human review → merge
+```
+
+## The plan issue
+
+The plan is a **GitHub issue**, one per story, labelled `plan`, titled `[STORY-XXX] Plan`.
+Its body holds the researched approach, acceptance criteria, and the commands/files it
+expects to touch. It is the **parent** of the task issues (`dw-tasks` links each task back
+with "Part of #<plan>"), and the durable checkpoint that survives a lost session.
+
+Its review is a **human gate**: a person reads, comments, and approves the issue on GitHub
+before `dw-tasks` decomposes it — no `dw-*` command produces or gates it (mirrors the
+`[human review + /review]` gate before a merge).
+
+## Producer → review pairing
+
+| Producer | Review | Covers |
+|----------|--------|--------|
+| `dw-story`     | `dw-review-story`     | the need: complete, and a goal not a spec |
+| `dw-plan`      | **human review** (the plan issue) | the approach covers the story, before decomposition |
+| `dw-tasks`     | `dw-review-tasks`     | the issues cover the plan; each lean; trace back to the plan |
+| `dw-implement` | `dw-review-implement` | the change delivers the issue, surgical, fits the project |
+| `dw-test-design` | *(verified by running the suite)* | tests pass, native to the framework |
+| `dw-create-pr` | *(human review + `/review`)* | the PR overview before merge |
+| `dw-merge`     | *(is the terminal gate)* | green CI + human review |
+
+No producer ships without a review covering its output.
+
+## Right-size it
+
+The plan stage is for non-trivial stories. A one-line doc change or a single-task story
+**skips `dw-plan`** — `dw-story` hands off straight to `dw-tasks` (or a lone issue). Three
+review passes plus a plan issue on a typo is ritual, not rigor.
+
+## What is reused, not rebuilt
+
+- **The story + issues** are the unit of work — a story in `docs/stories/`, its task
+  issues on GitHub.
+- **GitHub issues** already hold the work; the plan is one too (the parent), so the
+  approach, its review, and its history live where the tasks do — no separate plan store.
+- **CI** is the project's existing checks + human review — the merge gate, not a new pipeline.

--- a/.claude/skills/syncing-testlink/SKILL.md
+++ b/.claude/skills/syncing-testlink/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: syncing-testlink
+description: |
+  Syncs test cases from a project folder into TestLink by creating test suites,
+  importing test cases with HTML formatting, building a test plan, and assigning
+  cases. Use when a QA engineer wants to sync TestLink, import to TestLink,
+  upload test cases, or push test cases to TestLink.
+disable-model-invocation: true
+tools:
+  - testlink-mcp:list_projects
+  - testlink-mcp:create_test_suite
+  - testlink-mcp:create_test_case
+  - testlink-mcp:update_test_case
+  - testlink-mcp:list_test_cases_in_suite
+  - testlink-mcp:create_test_plan
+  - testlink-mcp:add_test_case_to_test_plan
+  - testlink-mcp:get_test_cases_for_test_plan
+---
+
+# syncing-testlink
+
+Syncs test cases from a project folder into TestLink: creates suites, imports cases with HTML formatting, builds a test plan, and assigns cases.
+
+## Progress Checklist
+
+Copy and track your progress:
+
+```
+- [ ] Step 1: Validate prerequisites
+- [ ] Step 2: List TestLink projects, confirm target
+- [ ] Step 3: Create test suite + child suites per scenario
+- [ ] Validate: Suite IDs and names
+- [ ] Step 4: Sync test cases (diff: skip/update/create)
+- [ ] Validate: Created/updated/skipped counts per suite
+- [ ] Step 5: Create test plan, add all cases
+- [ ] Step 6: Verify count matches local
+- [ ] Validate: Count match (PASS/FAIL) + test plan ID
+```
+
+## Steps
+
+### Step 1: Validate Prerequisites
+
+Check that:
+- `test_cases/README.md` exists
+- At least one `test_cases/TS-XX_*.md` file exists
+
+### Step 2: List Projects and Confirm Target
+
+Use `testlink-mcp:list_projects` to show available projects. Ask user to confirm the target project.
+
+### Step 3: Create Test Suites
+
+Run `/tl-create-suite` to create a parent test suite named after the project, then create child suites for each TS-XX scenario.
+
+**MCP tool:** `testlink-mcp:create_test_suite`
+
+### Validate
+
+List all created suite IDs and names. Confirm the hierarchy is correct.
+
+### Step 4: Sync Test Cases
+
+Run `/tl-create-case` for each TS-XX file. Use `/tl-format` for HTML formatting rules.
+
+Before creating, compare local test cases against TestLink using diff logic:
+- **MATCHING** (all fields same) → Skip
+- **DIFFERS** (name matches but fields differ) → Update only differing fields
+- **NEW** (name not found in TestLink) → Create with HTML formatting
+
+Comparison fields: `name`, `summary`, `preconditions`, `steps.actions`, `steps.expected_results`.
+
+After creation, verify preconditions were applied — update if empty.
+
+**MCP tools:** `testlink-mcp:create_test_case`, `testlink-mcp:update_test_case`, `testlink-mcp:list_test_cases_in_suite`
+
+### Validate
+
+Report per suite:
+- Created: N
+- Updated: N
+- Skipped (already matching): N
+
+### Step 5: Create Test Plan and Assign Cases
+
+Run `/tl-create-plan` to create a test plan using plain text (no HTML in notes field).
+
+Run `/tl-add-case-to-plan` to add all created/existing test cases to the plan.
+
+**MCP tools:** `testlink-mcp:create_test_plan`, `testlink-mcp:add_test_case_to_test_plan`
+
+### Step 6: Verify Count
+
+Use `testlink-mcp:get_test_cases_for_test_plan` to count cases in the plan.
+Compare against local test case count.
+
+### Validate
+
+Report:
+- Local test case count vs TestLink count
+- Count match: **PASS** or **FAIL**
+- Test Plan ID for future execution
+
+## Expected Input
+
+Path to project folder containing `test_cases/` with TS-XX files.
+
+## Next Step
+
+After syncing, verify the case counts in TestLink match the local `test_cases/`.

--- a/.gitignore
+++ b/.gitignore
@@ -75,12 +75,6 @@ Desktop.ini
 *.swo
 *~
 
-# Claude Code specific
-.claude/*
-!.claude/commands/
-!.claude/skills/
-!.claude/rules/
-
 # Cursor specific
 .cursor/
 !.cursor/commands/

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ Desktop.ini
 .claude/*
 !.claude/commands/
 !.claude/skills/
+!.claude/rules/
 
 # Cursor specific
 .cursor/


### PR DESCRIPTION
## Summary
- Add `.claude/commands/dev-workflow/` — full plan→build→PR→merge slash command set (dw-plan, dw-tasks, dw-implement, dw-create-pr, dw-merge, review/test-design commands)
- Add `.claude/commands/testlink/` — TestLink slash commands (create/get/list/update cases, suites, plans, executions, requirements; format and identify-type helpers)
- Add `.claude/skills/syncing-testlink/SKILL.md`
- Imported from the ai-qa-workflow repo (docs/command definitions only; no source changes)

## Test plan
- [ ] Commands appear under their namespaces and load without errors
- [ ] `syncing-testlink` skill is discoverable

Generated with [Claude Code](https://claude.com/claude-code)