### PR TITLE
Release v1.4.0: bump version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -462,7 +462,7 @@ class TestLinkAPI {
 }
 const server = new Server({
     name: 'testlink-mcp-server',
-    version: '1.3.0',
+    version: '1.4.0',
 }, {
     capabilities: {
         tools: {},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "testlink-mcp-server",
-  "version": "1.0.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "testlink-mcp-server",
-      "version": "1.0.0",
+      "version": "1.4.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "axios": "^1.7.2",
@@ -880,7 +880,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -1805,7 +1804,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testlink-mcp-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "MCP server for TestLink test case management",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -530,7 +530,7 @@ class TestLinkAPI {
 const server = new Server(
   {
     name: 'testlink-mcp-server',
-    version: '1.3.0',
+    version: '1.4.0',
   },
   {
     capabilities: {


### PR DESCRIPTION
## Release v1.4.0

Cuts a new versioned release for the changes merged since **v1.3.0**.

### Included since v1.3.0
- **#67** — list child suites via optional \`parent_suite_id\` (closes #52)
- **#66** — import dev-workflow + testlink commands / syncing utilities

### Changes in this PR
- Bump version to \`1.4.0\` in \`package.json\`, \`package-lock.json\`, and the MCP server version constant (\`src/index.ts\`)
- Rebuild \`dist/index.js\`

### After merge
- Tag \`v1.4.0\` on main
- Dispatch **Docker Publish** and **Release** workflows on the \`v1.4.0\` tag

\`\`\`bash
docker pull dogkeeper886/testlink-mcp:1.4.0
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)