### PR TITLE
Align .claude + CLAUDE.md with agent-workflows toolkit

### DIFF
--- a/.claude/commands/dev-workflow/dw-review-implement.md
+++ b/.claude/commands/dev-workflow/dw-review-implement.md
@@ -72,6 +72,34 @@ Fits between `/dw-implement` (does the work) and `/dw-create-pr` (opens the PR):
 
 ---
 
+## EXAMPLE
+
+    /dw-review-implement 6
+
+**Agent reads the issue + the branch diff, runs the checks:**
+
+    Delivers the issue (vs "Done When"):
+    ✓ design/wireframes/ holds tokens + components.css/js + components.html
+    ✓ no RUCKUS/R1 strings; brand neutral + configurable on qa-sidebar
+    ✓ demo content target-agnostic
+    ✓ components.html renders standalone in light + dark
+
+    Surgical:
+    ✓ only design/ added + two pointer lines in code/README.md
+    ✓ no dead code / debug leftovers; no unrelated edits
+
+    Fits the project:
+    ✓ core stays target-agnostic; markdown source of truth intact
+
+**Output:**
+
+    PASS — #6 delivers the issue and stays surgical.
+    A human reviews + tests; open a PR with /dw-create-pr 6 when ready.
+
+(Illustrative — a clean implementation. Real reviews often return REVISE.)
+
+---
+
 ## API Notes
 
 - Uses `gh` to read the issue; reads the branch diff with `git` — read-mostly

--- a/.claude/commands/dev-workflow/dw-test-design.md
+++ b/.claude/commands/dev-workflow/dw-test-design.md
@@ -33,7 +33,7 @@ Fits into the dev-workflow chain after /dw-implement and before /dw-create-pr.
         │   - Scan the project for existing test tooling:
         │
         │     Test Frameworks:
-        │     - cicd/tests/testcases/**/*.yml     → test-framework-template (YAML + dual-judge)
+        │     - cicd/tests/testcases/**/*.yml     → agent-workflows-runner (YAML + dual-judge)
         │     - tests/ + pytest.ini or conftest.py → pytest
         │     - __tests__/ or *.test.ts/js         → Jest
         │     - *.spec.ts/js                       → Jest / Vitest / Mocha
@@ -74,7 +74,7 @@ Fits into the dev-workflow chain after /dw-implement and before /dw-create-pr.
         │   │  - Commit test files to the issue branch
         │   │
         │   │  Examples by framework:
-        │   │  - test-framework-template → YAML in cicd/tests/testcases/{suite}/
+        │   │  - agent-workflows-runner → YAML in cicd/tests/testcases/{suite}/
         │   │  - pytest   → Python test files in tests/
         │   │  - Jest     → *.test.ts in __tests__/ or co-located
         │   │  - Go test  → *_test.go alongside source files
@@ -88,7 +88,7 @@ Fits into the dev-workflow chain after /dw-implement and before /dw-create-pr.
         │        - [ ] Step 2: description → expected result
         │      - Add a recommendation note:
         │        > This project has no automated test infrastructure.
-        │        > Consider adopting [test-framework-template](https://github.com/dogkeeper886/test-framework-template)
+        │        > Consider adopting [agent-workflows-runner](https://github.com/dogkeeper886/agent-workflows-runner)
         │        > for YAML-driven CI testing with dual-judge verification.
         │      - Ask the user: "Want me to create a follow-up issue for CI setup?"
         │        If yes → create issue labeled "enhancement" + "testing"
@@ -111,13 +111,13 @@ Fits into the dev-workflow chain after /dw-implement and before /dw-create-pr.
 
 ---
 
-## EXAMPLE 1: Project with test-framework-template
+## EXAMPLE 1: Project with agent-workflows-runner
 
     /dw-test-design 47
 
 **Agent detects cicd/tests/testcases/ with YAML files:**
 
-    Detected: test-framework-template (YAML + dual-judge)
+    Detected: agent-workflows-runner (YAML + dual-judge)
     CI: GitHub Actions (.github/workflows/test-pipeline.yml)
     Issue #47: enhancement → Type C (changed behavior)
 
@@ -167,7 +167,7 @@ Fits into the dev-workflow chain after /dw-implement and before /dw-create-pr.
     - [ ] Enter invalid email → shows validation error
 
     > This project has no automated test infrastructure.
-    > Consider adopting [test-framework-template](https://github.com/dogkeeper886/test-framework-template)
+    > Consider adopting [agent-workflows-runner](https://github.com/dogkeeper886/agent-workflows-runner)
     > for YAML-driven CI testing with dual-judge verification.
 
     Create follow-up issue for CI setup? [y/n]

--- a/.claude/commands/qa-workflow/qw-bind.md
+++ b/.claude/commands/qa-workflow/qw-bind.md
@@ -1,0 +1,54 @@
+# Bind a Test Doc to its Executable
+
+```
+Link each case in a test doc to the cicd executable that runs it — or port an
+existing executable into a new test-doc scaffold (the revert direction).
+
+Target: a docs/tests/TS-*.md scenario, or a cicd YAML to port.
+
+## PURPOSE
+
+Binding is **audit, not codegen** (per the qa-workflow design): the markdown owns
+*intent* (why / what), the cicd YAML owns *execution* (how it runs). This command
+establishes the link between them; its paired review `/qw-review-bind` checks the
+link still holds.
+
+Fits in the qa-workflow:
+
+    qw-plan → qw-cases → qw-bind → qw-review-bind → qw-run → dw-merge
+    (qw-run = `npm test` — the cicd runner; a phase, not a slash command)
+
+---
+
+## WORKFLOW
+
+### A. Forward — bind an existing test doc
+
+    /qw-bind docs/tests/TS-01-stack-lifecycle.md
+        │
+        ├─► For each `### TC-NN:` case, set a `Script:` line to the cicd YAML that
+        │   runs it (e.g. cicd/tests/testcases/integration/TC-INTEGRATION-001.yml).
+        ├─► Keep the case's Steps table aligned 1:1 with the YAML's steps — the
+        │   audit treats a step-count mismatch as `unbound`.
+        └─► Run `/qw-review-bind` to confirm the binding.
+
+### B. Revert — port an executable into a doc scaffold
+
+    /qw-bind cicd/tests/testcases/build/TC-BUILD-001.yml
+        │
+        ├─► Generate a scaffold from the YAML:
+        │     npm --prefix cicd/tests run port-yaml -- <yaml> > docs/tests/TS-NN-<slug>.md
+        │   The scaffold carries the steps and the `Script:` binding; objective,
+        │   expected results, story link, and namespace are TODOs.
+        ├─► Fill the TODOs: `namespace`, `story` (+ `story_hash`), each TC's
+        │   objective and Expected Result column. (The format contract is docs/tests/README.md.)
+        └─► Run `/qw-review-bind` to confirm the binding, then `/qw-cases`-style review.
+
+---
+
+## API Notes
+
+- `port-yaml` is a scaffolder, not a translator — a human/agent fills meaning.
+- `story_hash` = `sha256sum docs/stories/STORY-XXX.md` (the drift anchor).
+- Producer paired with `/qw-review-bind` (the audit).
+```

--- a/.claude/commands/qa-workflow/qw-cases.md
+++ b/.claude/commands/qa-workflow/qw-cases.md
@@ -1,0 +1,55 @@
+# Write the Test Docs
+
+```
+Turn a reviewed test plan into readable test docs in docs/tests/ — reusing vetted
+steps from the store instead of re-inventing them.
+
+Target: the scenarios approved by /qw-review-plan for a STORY-XXX.
+
+## PURPOSE
+
+The authoring producer of the qa-workflow — the test analogue of `dw-implement`.
+Writes each planned scenario as a `docs/tests/TS-*.md` doc in the format contract
+(docs/tests/README.md): front-matter + cases, each case a Steps table of
+Action / Expected Result rows.
+
+Fits in the qa-workflow:
+
+    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-run
+    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+
+---
+
+## WORKFLOW
+
+    /qw-cases STORY-003
+        │
+        ├─► Step 1: One file per scenario
+        │   - Create docs/tests/TS-NN-<slug>.md with front-matter:
+        │       id, title, namespace, story (+ story_hash = sha256 of the story file),
+        │       issue, status: green
+        │   - (Format and field meanings: docs/tests/README.md.)
+        │
+        ├─► Step 2: Write each case (TC) — reuse before re-inventing (dogfood the store)
+        │   - For each step you are about to write, ask the store first:
+        │       make query Q="<the action you mean>"
+        │     If a vetted step comes back close, phrase yours to match it — same
+        │     meaning, same good expected result — instead of coining a new one.
+        │   - Fill the Steps table: each row one Action + its Expected Result.
+        │
+        ├─► Step 3: Index + bind
+        │   - Load the new docs into the store:  npm --prefix step-store run load-tests
+        │   - Bind each case to its executable:  /qw-bind  (then /qw-review-bind)
+        │
+        └─► Step 4: Hand off
+            - Run `/qw-review-cases` to gate the docs.
+
+---
+
+## API Notes
+
+- Reuse is the point of the store: `search_step` (via `make query`) makes a vetted
+  step findable so coverage converges instead of duplicating.
+- `story_hash`: `sha256sum docs/stories/STORY-XXX.md`.
+- Producer paired with `/qw-review-cases`.
+```

--- a/.claude/commands/qa-workflow/qw-drift.md
+++ b/.claude/commands/qa-workflow/qw-drift.md
@@ -1,0 +1,49 @@
+# Check for Test Drift
+
+```
+Surface every test that no longer matches what it verifies — before a stale
+test passes quietly and a green build lies.
+
+Target: every test doc under docs/tests/ (runs in CI and on demand).
+
+## PURPOSE
+
+The freshness gate of the qa-workflow, and a review in its own right (it has no
+paired producer — it checks the whole set). Drift is silent until something looks;
+this looks, deterministically, every run.
+
+Fits in the qa-workflow:
+
+    … → qw-run → [human] → dw-merge   (qw-run = `npm test` — the cicd runner, not a slash command)
+                    └──────────────► qw-drift ──► back to qw-cases when stale
+
+---
+
+## WORKFLOW
+
+    /qw-drift
+        │
+        ├─► Run the gate:  npm --prefix cicd/tests run drift
+        │   Two deterministic signals, per case/scenario:
+        │     - STALE   — the linked story's sha256 no longer matches the doc's
+        │                 `story_hash` (the story moved since the test was synced).
+        │     - UNBOUND — the doc and its bound executable diverged (reuses the
+        │                 binding audit).
+        │   Exits non-zero if anything is stale or unbound (so CI fails on drift).
+        │
+        └─► On a finding:
+            - STALE: re-read the test against the changed story. If it still holds,
+              update `story_hash` (`sha256sum docs/stories/STORY-XXX.md`); if not,
+              fix the test via `/qw-cases` → `/qw-review-cases`.
+            - UNBOUND: fix via `/qw-bind` → `/qw-review-bind`.
+
+---
+
+## API Notes
+
+- Hash-first is deterministic and needs no stack; it runs in CI and on demand.
+- A semantic, embedding-based signal (softer "drifted in meaning", via the store)
+  is a planned advisory add — hash is the build-failing gate.
+- `status` in a test doc (green | stale | unbound) reflects this gate's verdict.
+- No paired producer — `qw-drift` *is* a review (the qa-workflow pairing rule).
+```

--- a/.claude/commands/qa-workflow/qw-plan.md
+++ b/.claude/commands/qa-workflow/qw-plan.md
@@ -1,0 +1,53 @@
+# Plan What to Test
+
+```
+Derive the scenarios that verify a story (or an on-request target) — the "what
+to test", before any test doc is written.
+
+Target: a STORY-XXX, or an ad-hoc request ("write a test for X").
+
+## PURPOSE
+
+The front of the qa-workflow — the test analogue of reading a story before
+implementing. It produces a short, reviewable list of **scenarios** (each a TS-to-be)
+that together cover the need, so `qw-cases` has a scoped plan to write against.
+
+Fits in the qa-workflow:
+
+    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-run
+    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+
+---
+
+## WORKFLOW
+
+    /qw-plan STORY-003
+        │
+        ├─► Step 1: Read the need
+        │   - If a STORY-XXX: read docs/stories/STORY-XXX.md (the need + "Success Looks Like").
+        │   - If an on-request target: restate what behaviour is to be verified.
+        │
+        ├─► Step 2: Check what already exists (dogfood the store)
+        │   - Search the step-store for steps/cases already covering this:
+        │       make query Q="<the behaviour>"
+        │     so the plan reuses vetted coverage instead of duplicating it.
+        │   - List the docs/tests/ scenarios already linked to this story:
+        │       grep -l 'story: STORY-XXX' docs/tests/
+        │
+        ├─► Step 3: Propose scenarios
+        │   - Break the need into scenarios (TS-to-be), each:
+        │     • one coherent slice of behaviour, • independently runnable,
+        │     • mappable to one or more cicd executables.
+        │   - For each, name the cases (TC-to-be) it will hold, at a sentence each.
+        │
+        └─► Step 4: Hand off
+            - Present the scenario list for `/qw-review-plan`, then `/qw-cases`.
+
+---
+
+## API Notes
+
+- A scenario here is a *plan item*, not yet a file — `qw-cases` writes the doc.
+- The story is the goal; keep the plan to coverage, not step detail.
+- Producer paired with `/qw-review-plan`.
+```

--- a/.claude/commands/qa-workflow/qw-review-bind.md
+++ b/.claude/commands/qa-workflow/qw-review-bind.md
@@ -1,0 +1,52 @@
+# Review a Test Doc ↔ Script Binding
+
+```
+Audit that each test doc and its bound executable still agree — flag any case
+whose doc and script have diverged as `unbound`.
+
+Target: the docs/tests/ scenarios (all, or one named file).
+
+## PURPOSE
+
+The paired review for `/qw-bind`. Binding is audit-not-codegen, so something has to
+*check* that the markdown and the YAML haven't drifted apart. This runs the
+deterministic audit and adds a human/agent pass for meaning.
+
+Fits in the qa-workflow:
+
+    qw-plan → qw-cases → qw-bind → qw-review-bind → qw-run → dw-merge
+    (qw-run = `npm test` — the cicd runner; a phase, not a slash command)
+
+---
+
+## WORKFLOW
+
+    /qw-review-bind
+        │
+        ├─► Step 1: Run the deterministic audit
+        │     npm --prefix cicd/tests run audit-bind
+        │   For each case it checks:
+        │     - the `Script:` path resolves to a file, and
+        │     - the doc's step count matches the YAML's step count.
+        │   A failure prints `UNBOUND` with the reason; the command exits non-zero
+        │   (so CI and the drift gate, #27, can gate on it).
+        │
+        ├─► Step 2: Read the meaning the audit can't
+        │   For each `bound` case, skim that the doc's Actions/Expected Results
+        │   still describe what the YAML actually does — structure can match while
+        │   meaning has drifted. Flag any semantic mismatch.
+        │
+        └─► Step 3: Decision
+            - PASS: every case `bound` (audit exits 0) and meaning holds.
+            - REVISE: for each `UNBOUND` (or semantic mismatch), fix the doc's
+              Steps/`Script:` or the binding — smallest change first — then re-run.
+
+---
+
+## API Notes
+
+- The audit (`audit-bind`) is structural + deterministic; it is the runnable check
+  CI and `/qw-drift` reuse. Semantic agreement is the reviewer's job.
+- `unbound` is one of the test doc's `status` values (docs/tests/README.md).
+- Review paired with the producer `/qw-bind`.
+```

--- a/.claude/commands/qa-workflow/qw-review-cases.md
+++ b/.claude/commands/qa-workflow/qw-review-cases.md
@@ -1,0 +1,48 @@
+# Review the Test Docs
+
+```
+Check each test doc does one clear job, has observable steps, and traces back to
+its story — before it is bound and run.
+
+Target: the docs/tests/TS-*.md docs written by /qw-cases for a STORY-XXX.
+
+## PURPOSE
+
+The paired review for `/qw-cases`. The test-doc analogue of `dw-review-implement`:
+gates the written docs for quality and traceability.
+
+Fits in the qa-workflow:
+
+    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-run
+    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+
+---
+
+## WORKFLOW
+
+    /qw-review-cases STORY-003
+        │
+        ├─► Step 1: Each doc
+        │   - [ ] One scenario, one job; cases are coherent slices of it.
+        │   - [ ] Front-matter complete and resolvable: story file exists,
+        │         story_hash matches it, namespace set, status present.
+        │   - [ ] Each step's Expected Result is observable — checkable, not vague.
+        │   - [ ] Conforms to the format contract (docs/tests/README.md).
+        │
+        ├─► Step 2: Traceability
+        │   - [ ] story → doc → (script, via qw-bind) resolves both ways.
+        │   - [ ] No duplicate of an existing scenario for the same story.
+        │
+        └─► Step 3: Decision
+            - PASS: docs do their job and trace back → proceed to `/qw-bind` (if not
+              yet bound), then run it (`make up` + the cicd runner).
+            - REVISE: fix the named doc — smallest change first — and re-check.
+
+---
+
+## API Notes
+
+- This reviews the *doc* (intent); `/qw-review-bind` reviews the doc↔script binding.
+- Published-deliverable phrasing/typography is out of scope here.
+- Review paired with the producer `/qw-cases`.
+```

--- a/.claude/commands/qa-workflow/qw-review-plan.md
+++ b/.claude/commands/qa-workflow/qw-review-plan.md
@@ -1,0 +1,46 @@
+# Review the Test Plan
+
+```
+Check the proposed scenarios cover the story — and stay coverage, not a frozen
+step-by-step spec.
+
+Target: the scenario list from /qw-plan for a STORY-XXX — as proposed in the
+conversation, or as already realized in docs/tests/ when reviewing after the fact.
+
+## PURPOSE
+
+The paired review for `/qw-plan`. Gates the plan before `qw-cases` writes any docs,
+so coverage gaps are caught cheaply.
+
+Fits in the qa-workflow:
+
+    qw-plan → qw-review-plan → qw-cases → qw-review-cases → qw-bind → qw-run
+    (qw-run = `make up` + the cicd runner — a phase, not a slash command)
+
+---
+
+## WORKFLOW
+
+    /qw-review-plan STORY-003
+        │
+        ├─► Step 1: Coverage vs the story
+        │   - [ ] Every item in the story's "Success Looks Like" maps to a scenario.
+        │   - [ ] Nothing essential to verifying the story is missing.
+        │   - [ ] No scenario goes beyond the story's need.
+        │
+        ├─► Step 2: Each scenario
+        │   - [ ] One coherent slice; independently runnable.
+        │   - [ ] Maps to at least one cicd executable (or names the gap to author).
+        │   - [ ] No duplication of a scenario already in docs/tests/ (grep the story link).
+        │
+        └─► Step 3: Decision
+            - PASS: covers the story → proceed to `/qw-cases`.
+            - REVISE: name the missing or excess scenario; back to `/qw-plan`.
+
+---
+
+## API Notes
+
+- Coverage gate only — step detail is `qw-cases`/`qw-review-cases`'s job.
+- Review paired with the producer `/qw-plan`.
+```

--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -1,13 +1,14 @@
 ---
 paths:
-  - "commands/dev-workflow/**/*.md"
+  - ".claude/commands/dev-workflow/**/*.md"
 ---
 
 # dev-workflow
 
 Turns a need into shipped code. A story states the **need** (a goal, not a spec); a
 **plan issue** states the agreed **approach**; task issues carry the *how* as it's worked
-out. Each producer is paired with a review — no producer ships without one.
+out. Each producer is paired with a review — the same discipline `qa-workflow` and
+`reviewing-artifacts` enforce.
 
 ## The flow
 
@@ -61,12 +62,12 @@ No producer ships without a review covering its output.
 
 The plan stage is for non-trivial stories. A one-line doc change or a single-task story
 **skips `dw-plan`** — `dw-story` hands off straight to `dw-tasks` (or a lone issue). Three
-review passes plus a plan issue on a typo is ritual, not rigor.
+review passes plus a plan issue on a typo is ritual, not rigor (see CLAUDE.md §5).
 
 ## What is reused, not rebuilt
 
-- **The story + issues** are the unit of work — a story in `docs/stories/`, its task
-  issues on GitHub.
+- **The story + issues** are shared with `qa-workflow` — one `STORY-XXX` gets both `dw-*`
+  (code) and `qw-*` (tests).
 - **GitHub issues** already hold the work; the plan is one too (the parent), so the
   approach, its review, and its history live where the tasks do — no separate plan store.
 - **CI** is the project's existing checks + human review — the merge gate, not a new pipeline.

--- a/.claude/rules/qa-workflow.md
+++ b/.claude/rules/qa-workflow.md
@@ -1,0 +1,50 @@
+---
+paths:
+  - ".claude/commands/qa-workflow/**/*.md"
+---
+
+# qa-workflow
+
+A sibling to `dev-workflow`. Where dev-workflow turns a need into shipped code, qa-workflow
+turns a story into **trustworthy test docs** — readable markdown in `docs/tests/`, authored
+from a reviewed test plan. This repo owns the **authoring** half (markdown + GitHub); binding
+those docs to a runner and running them is the project's own layer.
+
+## The flow
+
+```
+   docs/stories/STORY-XXX.md   ──or──  "write a test for X"   (on request)
+            │
+            ▼
+   qw-plan ───────► qw-review-plan      what to test — scenarios persisted as the
+            │                            [STORY-XXX] Test Plan issue
+            ▼
+   qw-cases ──────► qw-review-cases     write docs/tests/TS-*.md (the format contract)
+            │
+            ▼
+   → hand off to the project's binding + run layer
+```
+
+## The test-plan issue
+
+`qw-plan`'s scenarios persist as a **GitHub issue**, titled `[STORY-XXX] Test Plan`, labelled
+`test-plan` (distinct from dev's `[STORY-XXX] Plan`). `qw-review-plan` reviews it; `qw-cases`
+reads it and records the issue number in each `TS-*.md` `plan:` field.
+
+## Producer → review pairing
+
+| Producer | Review | Covers |
+|----------|--------|--------|
+| `qw-plan`  | `qw-review-plan`  | does the plan cover the story? |
+| `qw-cases` | `qw-review-cases` | each doc: one job, observable, traces back |
+
+No producer ships without a review covering its output.
+
+## What this owns — and what it hands off
+
+- **Owns:** the authoring flow + the `docs/tests/` test-doc format (the contract). Self-contained
+  — markdown + GitHub only.
+- **Hands off:** binding each case to an executable and running it is the **project's binding +
+  run layer**. Reusing vetted steps (a search index) is an **optional** project enhancement.
+
+The format a test doc must follow is `docs/tests/README.md`.

--- a/.claude/rules/test-yaml-format.md
+++ b/.claude/rules/test-yaml-format.md
@@ -1,0 +1,87 @@
+---
+paths:
+  - "cicd/tests/testcases/**/*.yml"
+  - "cicd/tests/src/types.ts"
+  - "cicd/tests/src/loader.ts"
+---
+
+# Test Case YAML Format
+
+## Schema
+
+```yaml
+id: TC-[SUITE]-[NUMBER]
+testlink_id: 17                    # TestLink test case ID this maps to (this repo)
+name: Human-readable test name
+suite: build|integration|e2e      # Extensible — add custom suites in config.ts
+goal: One-line objective for LLM judge context
+priority: 1                        # Lower = runs first
+timeout: 30000                     # Milliseconds
+dependencies: [TC-SUITE-001]       # Tests that must pass first
+tags: [feature-name]               # For --tag filtering (optional)
+
+steps:
+  - name: Step description
+    command: shell command to execute
+    timeout: 5000                  # Optional, overrides test timeout
+    expectPatterns:                # All must match (regex)
+      - "pattern"
+    rejectPatterns:                # None should match (regex)
+      - "error"
+    capture:                       # Extract values from JSON output
+      varName: "json.path"
+
+criteria: |
+  Human-readable criteria for LLM judge evaluation.
+```
+
+## Tags
+
+Tags enable per-feature CI workflows. Use feature names or capability areas:
+
+```yaml
+tags: [auth, api]          # Feature tags
+tags: [build, compile]     # Suite-aligned tags
+tags: [smoke]              # Test category tags
+```
+
+Filter by tag: `npm test -- --tag auth` or `npm run list -- --tag auth`
+
+## Variable Capture
+
+Steps can extract values from JSON output and inject them into later steps:
+
+```yaml
+steps:
+  - name: Create resource
+    command: curl -s -X POST http://localhost:3000/api/resources
+    capture:
+      resourceId: "id"
+  - name: Verify resource
+    command: curl -s http://localhost:3000/api/resources/{{resourceId}}
+```
+
+**Path syntax:**
+- `id` — direct field
+- `data.name` — nested field
+- `data[name=foo].id` — array find by field match
+- `$[type=user].email` — root array find
+
+Variables resolve from captured step output first, then fall back to `process.env`. This enables CI-friendly patterns like `{{TEST_API_KEY}}` without hardcoding values.
+
+MCP double-encoded responses (`content[0].text` wrapping) are automatically unwrapped.
+
+## Suite Guidelines
+
+- `build` — compilation, dependency checks, environment validation
+- `integration` — single tool/API calls, verify output format and correctness
+- `e2e` — multi-step workflows, verify end-to-end state
+
+Add custom suites by extending the `SUITES` array in `config.ts`.
+
+## ID Format
+
+- `TC-BUILD-XXX`
+- `TC-INT-XXX`
+- `TC-E2E-XXX`
+- Custom: `TC-{SUITE}-XXX` (match your suite names)

--- a/.claude/rules/workflow-patterns.md
+++ b/.claude/rules/workflow-patterns.md
@@ -1,0 +1,64 @@
+---
+paths:
+  - ".github/workflows/**/*.yml"
+---
+
+# CI Workflow Patterns
+
+## Per-Feature Workflow Pattern
+
+Split CI into composable, independently triggerable workflows:
+
+```
+.github/workflows/
+├── build.yml                # Standalone build step
+├── test-run.yml             # Reusable test runner (called by feature workflows)
+├── test-<feature>.yml       # One per feature (~25 lines, thin delegator)
+└── ci.yml                   # Full pipeline: build -> all features in parallel
+```
+
+**Adding a new feature test:**
+1. Tag test cases: `tags: [my-feature]`
+2. Copy `test-feature-example.yml` -> `test-my-feature.yml`
+3. Change the `tag` input value to `my-feature`
+4. Add the new workflow as a job in `ci.yml`
+
+### Suite-Based Alternative
+
+For projects organized by test suite rather than feature:
+
+```
+.github/workflows/
+├── build.yml
+├── test-run.yml             # Same reusable runner
+├── test-build.yml           # Uses --suite build
+├── test-integration.yml     # Uses --suite integration
+└── ci.yml                   # Orchestrates all suites
+```
+
+Both patterns use `test-run.yml` as the single reusable job.
+
+## Key Design Decisions
+
+**Dual triggers:** Each workflow supports both `workflow_dispatch` (manual, with dropdowns) and `workflow_call` (callable from pipeline). This lets you run features independently or as part of the full CI.
+
+**Judge mode dropdown:** Each workflow offers `simple` (default — fast, deterministic, no model) or `dual` (simple + the opt-in LLM judge). The workflow sets `LLM_JUDGE_MODE` from this input; the runner is simple-only unless it reads `dual`.
+
+## Environment Variables
+
+The LLM judge reaches its model through the Anthropic SDK, so any Anthropic-compatible
+endpoint (the hosted API or a local one) is a matter of configuration. Set these via
+GitHub repository variables/secrets (`Settings > Variables/Secrets > Actions`):
+
+| Variable | Purpose | Example |
+|----------|---------|---------|
+| `LLM_JUDGE_MODE` | `simple` (default) or `dual` (opt in the LLM judge) | `dual` |
+| `LLM_JUDGE_MODEL` | Model for judging | `claude-haiku-4-5-20251001` |
+| `LLM_JUDGE_URL` | Base URL of an Anthropic-compatible endpoint (unset → hosted Anthropic API) | `http://localhost:11434` |
+| `ANTHROPIC_API_KEY` | API key for the hosted API (secret; a placeholder works for a local endpoint that ignores auth) | `sk-ant-...` |
+
+**Local endpoint:** To judge against a local Anthropic-compatible model server, point `LLM_JUDGE_URL` at it. Keeping the judge on a separate endpoint from any model your project itself tests avoids resource contention.
+
+## Legacy Workflows
+
+`test-pipeline.yml` and `test-suite.yml` are the original suite-based workflows. They still work but the per-feature pattern (`ci.yml` + `test-run.yml`) is recommended for projects with many test cases.

--- a/.claude/skills/add-tool/SKILL.md
+++ b/.claude/skills/add-tool/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: add-tool
+description: Add new MCP tools following standard patterns and guidelines
+user-invocable: true
+---
+
+# Add New MCP Tool
+
+Add a new MCP tool to this server following established patterns and guidelines.
+
+## Process Overview
+
+This command guides you through a systematic process to:
+1. Analyze API behavior to understand the operation
+2. Study existing codebase patterns
+3. Implement consistent code following project guidelines
+4. Review for compliance with project standards
+
+---
+
+## Phase 1: Understand the Project
+
+### Study Project Guidelines
+- Read the project's CLAUDE.md file to understand architectural patterns
+- Identify the distinction between operation types (read-only vs async)
+- Review parameter ordering conventions
+- Understand error handling patterns
+
+### Study Existing Implementation
+- Search for similar existing tools in the services layer
+- Examine how existing tools are registered in the MCP server
+- Review how existing tools handle errors
+- Identify polling and retry patterns for async operations
+
+**Action:** Use file search tools to locate similar implementations before writing any code.
+
+---
+
+## Phase 2: Gather Requirements
+
+### Understand the Operation
+Ask for or determine:
+- HTTP method and endpoint (or equivalent operation)
+- Request/response structure
+- Whether response includes async operation indicators
+- Business purpose of the operation
+
+### Determine Operation Type
+
+| Type | Characteristics | Template |
+|------|----------------|----------|
+| **Read-only query** | GET/query, no side effects | No retry params, return directly |
+| **Async with polling** | Create/delete/update, returns tracking ID | `maxRetries`, `pollIntervalMs` |
+| **Conditional async** | Multi-step, some steps conditional | Spread operator with conditional |
+| **Retrieve-then-update** | GET current state, merge, PUT back | Preserve all existing fields |
+| **Type-based conditional** | Different payloads per resource type | Switch/if on type |
+| **Type-based early return** | Entirely different flows per type | Early return pattern |
+| **Optional payload** | Empty body support for PUT/POST | Conditional body construction |
+
+**Action:** Confirm operation type before proceeding.
+
+---
+
+## Phase 3: Pattern Analysis
+
+### Find the Most Similar Existing Tool
+Search the codebase for:
+- Functions with the same operation type
+- Functions calling similar API endpoints
+- Functions with matching patterns (polling, query, CRUD)
+
+### Copy the Pattern Exactly
+From the similar tool, note:
+- Parameter order and types
+- Default values
+- API URL construction
+- Request/response handling
+- Error handling structure
+- Polling logic (if async)
+
+**Action:** Read the complete implementation of the most similar tool to use as a template.
+
+---
+
+## Phase 4: Implementation Planning
+
+### Create Checklist
+Plan the implementation:
+1. Implement service layer function
+2. Register tool in MCP server
+3. Implement request handler
+4. Review against guidelines
+5. Review tool description for AI agent clarity
+
+### Identify Potential Issues
+Before coding, consider:
+- Unique aspects not covered by existing patterns
+- Data transformation needs
+- Pagination requirements
+- Authentication differences
+
+**Action:** Stop and ask questions if the operation reveals patterns not seen in existing code.
+
+---
+
+## Phase 5: Service Layer Implementation
+
+### Implement Core Function
+Follow the pattern from the most similar existing tool:
+- Use exact parameter ordering from the pattern
+- Use exact default values from the pattern
+- Copy API URL construction logic
+- Copy request structure
+- Copy error handling approach
+
+### For Async Operations
+- Copy polling loop exactly from existing async tool
+- Do not modify retry defaults without approval
+- Do not modify polling interval without approval
+- Standard defaults: `maxRetries = 5`, `pollIntervalMs = 2000`
+
+### For Read-Only Operations
+- Do not add retry parameters
+- Do not add polling logic
+- Return response data directly
+- Follow query/filter patterns if applicable
+
+---
+
+## Phase 6: MCP Tool Registration
+
+### Register Tool Schema
+- Define tool name following project naming conventions (snake_case)
+- Write clear description (see Phase 9.5)
+- Define input schema matching function parameters
+- Mark required vs optional parameters correctly
+- Add retry parameters only for async operations
+
+---
+
+## Phase 7: Request Handler Implementation
+
+### Implement Handler
+- Add case for the new tool
+- Destructure parameters with correct defaults
+- Obtain authentication using existing pattern
+- Call service function with parameters in correct order
+- Return response in standard format
+- Copy error handling exactly from similar handler
+
+---
+
+## Phase 8: Compliance Review
+
+### Verify Against Project Standards
+- Parameter order matches conventions
+- Default values match conventions
+- Error handling matches existing patterns
+- Response structure matches existing patterns
+- No hardcoded values that should be configurable
+- Naming conventions followed
+
+---
+
+## Phase 9: Tool Description Review for AI Agent Clarity
+
+### Ensure Tool Description is Actionable
+
+AI agents need clear descriptions to use tools correctly. Follow this structure:
+
+```
+[Action verb] [what it does]. [Additional context].
+PREREQUISITE: [condition] (use [tool_name]).
+REQUIRED: [param1] (use [tool_name] to get [param1]) + [param2].
+[Special notes].
+```
+
+**Parameter descriptions should include tool references:**
+```
+'ID of the resource to delete (use query_resources to find resource ID)'
+'Array of venue IDs (use get_venues to get venue IDs)'
+```
+
+**Checklist:**
+- [ ] Description starts with clear action and purpose
+- [ ] Prerequisites listed with tool references
+- [ ] Required parameters explain how to obtain IDs
+- [ ] Destructive operations include warnings
+- [ ] Batch vs single operation scope is clear
+
+---
+
+## Phase 10: Summary
+
+### Report
+- Files modified and functions added
+- Pattern used as basis
+- Operation type and characteristics
+- Any deviations from standard patterns (with justification)
+
+### Testing Guidance
+- How to manually test the new tool
+- Expected input and output
+- Edge cases to verify
+- Suggest: `/ci-testcase` to generate automated tests
+
+---
+
+## Key Principles
+
+1. **Consistency First**: Copy existing patterns exactly rather than inventing new approaches
+2. **No Assumptions**: Stop and ask when unclear
+3. **No Modifications**: Do not modify retry defaults, polling intervals, or error handling without approval
+4. **Pattern Matching**: Find the most similar existing tool and follow its structure
+5. **Question Everything**: If something seems inconsistent, investigate and ask

--- a/.claude/skills/ci-run/SKILL.md
+++ b/.claude/skills/ci-run/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: ci-run
+description: Execute test cases with the simple judge by default, or opt in the LLM judge
+user-invocable: true
+---
+
+# Run Test Cases
+
+Execute test cases and evaluate results. The simple (deterministic) judge is the
+default verdict; the LLM judge is an opt-in second opinion (`LLM_JUDGE_MODE=dual`).
+
+```
+$ARGUMENTS
+
+## PURPOSE
+
+Run YAML test cases by executing commands and evaluating results against patterns and criteria.
+
+---
+
+## AGENT WORKFLOW
+
+### Step 1: Load Test Cases
+
+Input can be:
+- A test ID (e.g., `TC-INT-001`) — run that specific test
+- A suite name (e.g., `integration`) — run all tests in that suite
+- A tag name (e.g., `auth`) — run all tests with that tag
+- Empty — run all tests
+
+Read YAML test case files from `cicd/tests/testcases/`.
+
+### Step 2: Resolve Dependencies
+
+Sort tests by:
+1. Dependencies (tests that depend on others run after)
+2. Priority (lower number = runs first)
+
+If running a specific test that has dependencies, auto-include them.
+
+### Step 3: Execute Each Test
+
+For each test case, for each step:
+
+1. **Substitute variables** — replace `{{varName}}` with captured values from previous steps (falls back to `process.env`)
+2. **Execute the command** specified in `command`
+3. **Capture the output** (stdout and stderr)
+4. **Check expectPatterns** — each regex must match somewhere in the output
+5. **Check rejectPatterns** — none of these regexes should match
+6. **Capture variables** — if `capture` is defined, extract values from JSON output
+7. **Record result**: PASS or FAIL with evidence
+
+If a step fails, continue with remaining steps but note the failure.
+
+### Step 4: Judge Results
+
+For each test case, determine overall verdict:
+- **PASS** — all steps passed, all patterns matched, no errors detected
+- **FAIL** — any step failed, with details on which and why
+
+If a test has `criteria` and `goal` fields, evaluate whether the output semantically satisfies them.
+
+### Step 5: Report
+
+Output a summary table:
+
+```
+Test Results
+============
+TC-INT-001  Query resources            PASS  (1.2s)
+TC-INT-002  Create and verify          FAIL  (step 2: expected pattern "active" not found)
+TC-E2E-001  Full lifecycle             PASS  (5.8s)
+
+Summary: 2/3 passed
+Duration: 8.2s
+```
+
+If any test failed, show:
+- Which step failed
+- Expected vs actual output (truncated)
+- Suggested fix or investigation
+
+### Alternative: Use the CLI
+
+Instead of agent-based execution, use the built-in CLI:
+
+```bash
+cd cicd/tests
+npm test                        # All tests (simple judge — fast, no model)
+npm test -- --suite integration # Specific suite
+npm test -- --id TC-INT-001     # Specific test
+npm test -- --tag auth          # Tests tagged 'auth'
+npm test -- --dry-run           # Preview only
+LLM_JUDGE_MODE=dual npm test    # Opt in the LLM judge (env, not a flag)
+```
+
+**Environment variables for CI:**
+- `LLM_JUDGE_MODE` — `simple` (default) or `dual` (opt in the LLM judge)
+- `LLM_JUDGE_MODEL` — Model for judging (default: `claude-haiku-4-5-20251001`)
+- `LLM_JUDGE_URL` — Base URL of an Anthropic-compatible endpoint (unset → hosted Anthropic API)
+- `ANTHROPIC_API_KEY` — API key for the hosted API
+
+---
+
+## OUTPUT
+
+Test results summary with pass/fail status for each test case.

--- a/.claude/skills/ci-testcase/SKILL.md
+++ b/.claude/skills/ci-testcase/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: ci-testcase
+description: Generate YAML test cases from requirements or acceptance criteria
+user-invocable: true
+---
+
+# Create Test Case
+
+Generate a YAML test case file from requirements or acceptance criteria.
+
+```
+$ARGUMENTS
+
+## PURPOSE
+
+Read requirements (story, ticket, or description) and generate YAML test case(s) that verify the acceptance criteria.
+
+---
+
+## AGENT WORKFLOW
+
+### Step 1: Understand Requirements
+
+Input can be:
+- A story/requirement file path — read and analyze it
+- A description of what to test — use it directly
+- A ticket ID — look for related docs or ask the user
+
+Identify:
+- What functionality to test
+- What commands or tools to call
+- What output to expect
+- What would indicate failure
+
+### Step 2: Review Existing Tests
+
+Read existing test cases in `cicd/tests/testcases/` to:
+- Find the next available ID number per suite
+- Follow existing naming and pattern conventions
+- Avoid duplicating existing coverage
+
+### Step 3: Generate Test Case YAML
+
+Create test case file(s) in `cicd/tests/testcases/<suite>/` using this format:
+
+```yaml
+id: TC-[SUITE]-[NUMBER]
+name: Descriptive test name
+suite: build|integration|e2e
+goal: One-line test objective for LLM judge
+priority: 1-10 (lower = runs first)
+timeout: 30000
+dependencies: []
+tags: [feature-name]
+
+steps:
+  - name: Step description
+    command: <shell command or mcp-client.ts call>
+    timeout: 5000              # Optional
+    expectPatterns:
+      - "regex pattern"
+    rejectPatterns:
+      - "error"
+    capture:                   # Optional: extract values for later steps
+      varName: "json.path"
+
+criteria: |
+  Human-readable criteria for LLM judge evaluation.
+```
+
+**Suite guidelines:**
+- `build` — compilation, dependency checks, environment validation
+- `integration` — single tool/API calls, verify output format and correctness
+- `e2e` — multi-step workflows, verify end-to-end state
+
+**ID format:** `TC-BUILD-XXX`, `TC-INT-XXX`, `TC-E2E-XXX`
+
+**Tags:** Use feature names or capability areas (e.g., `auth`, `api`, `build`). Tags enable per-feature CI workflows via `--tag`.
+
+**For MCP tool testing:**
+```yaml
+command: npx tsx cicd/tests/src/mcp-client.ts <tool_name> '{"arg":"value"}'
+```
+
+**For shell command testing:**
+```yaml
+command: curl -s http://localhost:3000/api/endpoint
+```
+
+**For multi-step with variable capture:**
+```yaml
+steps:
+  - name: Create resource
+    command: <command that returns JSON>
+    capture:
+      resourceId: "id"
+  - name: Use captured value
+    command: <command using {{resourceId}}>
+```
+
+Variables resolve from captured step output first, then fall back to `process.env`.
+
+### Step 4: Report
+
+Show the user:
+- Test case files created
+- What each test validates
+- Suggest: `/ci-run` to execute tests
+
+---
+
+## OUTPUT
+
+Paths to created test case files.

--- a/.claude/skills/install/SKILL.md
+++ b/.claude/skills/install/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: install
+description: Install test framework into a project with agent-driven configuration
+user-invocable: true
+---
+
+# Install Test Framework
+
+Install the dual-judge test framework into the current project.
+
+```
+$ARGUMENTS
+
+## PURPOSE
+
+Install the test framework from the template source into the user's current working directory, adapting configuration to the project's needs.
+
+---
+
+## AGENT WORKFLOW
+
+### Step 1: Locate Template Source
+
+Input is the path to the agent-workflows-runner repo:
+- If provided: use it directly
+- If empty: check common locations (`~/src/agent-workflows-runner`, `../agent-workflows-runner`)
+- If not found: ask the user for the path
+
+Read the template's `CLAUDE.md` to understand available components and the installation flow.
+
+### Step 2: Detect Project Context
+
+Examine the current working directory:
+
+1. **Read `package.json`** — extract project name, check for `@modelcontextprotocol/sdk`
+2. **Check for `docker-compose.yml`** — Docker project?
+3. **Check for existing `cicd/tests/`** — fresh install or update?
+4. **Check `.claude/skills/`** — what skills are already installed?
+
+### Step 3: Ask Configuration Questions
+
+Prompt the user with detected defaults:
+
+- **Project name** — from package.json or ask
+- **Judge mode** — default: `simple` (deterministic, no model); `dual` opts in the LLM judge
+- **LLM judge model** — default: `claude-haiku-4-5-20251001` (used in dual mode)
+- **LLM judge endpoint** — optional Anthropic-compatible base URL (unset → hosted Anthropic API)
+- **Include MCP client?** — auto-yes if MCP SDK detected
+- **Include Docker log collector?** — auto-yes if docker-compose found
+- **Install Claude skills?** — recommend yes
+- **Install example test cases?** — yes for fresh install, ask for updates
+
+### Step 4: Install
+
+1. **Create directories:**
+   - `cicd/tests/src/judge/`
+   - `cicd/tests/src/reporter/`
+   - `cicd/tests/testcases/{build,integration,e2e}/`
+   - `cicd/scripts/`
+   - `cicd/results/`
+
+2. **Copy files** from template source to current project:
+   - Core: `cli.ts`, `config.ts`, `types.ts`, `loader.ts`, `executor.ts`
+   - Judges: `judge/simple-judge.ts`, `judge/llm-judge.ts`, `judge/index.ts`
+   - Reporters: `reporter/console.ts`, `reporter/json.ts`, `reporter/index.ts`
+   - Supporting: `package.json`, `tsconfig.json`
+   - Conditional: `log-collector.ts` (Docker), `mcp-client.ts` (MCP)
+   - Skills: `ci-testcase`, `ci-run`, `add-tool` (to `.claude/skills/`)
+   - Rules: `test-yaml-format.md`, `workflow-patterns.md` (to `.claude/rules/`)
+   - Examples: test case YAML files (if selected)
+   - Scripts: `format-results.sh`
+
+3. **Adapt config.ts** — replace placeholder values with user's answers:
+   - `projectName: 'my-project'` -> actual project name
+   - `sessionPrefix: 'test-session'` -> `'{name}-session'`
+   - `llm.model` -> user's judge model (default `claude-haiku-4-5-20251001`)
+   - `llm.baseUrl` -> user's endpoint, if any (else leave unset for the hosted Anthropic API)
+
+4. **Create `.gitignore`** in `cicd/results/`:
+   ```
+   *
+   !.gitignore
+   ```
+
+5. **Run `npm install`** in `cicd/tests/`
+
+### Step 5: Verify
+
+1. Run `cd cicd/tests && npm run build` — must compile
+2. Run `npm run list` — must load test cases
+3. If either fails, diagnose and fix
+
+### Step 6: Report
+
+Show the user:
+- What was installed (components list)
+- Configuration values applied
+- Next steps:
+  - Write test cases: `cicd/tests/testcases/<suite>/*.yml`
+  - Customize error patterns: `cicd/tests/src/config.ts`
+  - Run tests: `cd cicd/tests && npm test`
+  - Generate test cases: `/ci-testcase`
+
+---
+
+## FOR UPDATES
+
+If `cicd/tests/` already exists:
+
+1. **Preserve user files** — do NOT overwrite:
+   - `config.ts` (user's configuration)
+   - `testcases/**/*.yml` (user's test cases)
+   - Any files the user has customized
+
+2. **Update framework files** — compare and update:
+   - `executor.ts`, `loader.ts`, `types.ts`, `cli.ts`
+   - Judge and reporter files
+   - `package.json` (merge dependencies, don't overwrite scripts)
+
+3. **Show diff** before applying updates — let user approve changes
+
+---
+
+## OUTPUT
+
+Summary of installed/updated components with next steps.

--- a/.claude/skills/reviewing-artifacts/SKILL.md
+++ b/.claude/skills/reviewing-artifacts/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: reviewing-artifacts
+description: |
+  Reviews any workflow artifact — the commands, skills, and project docs that are the
+  tooling (READMEs, stories, CLAUDE.md, and the like) — against five goal questions:
+  one clear job, complete, a goal not a frozen spec, fits the project, right for its
+  reader. Also runs a producer→review pairing coverage pass that flags any producer
+  shipped without a paired review. It judges whether an artifact does its job; how a
+  human-read doc (the README, docs/ prose) looks and reads goes to the typography +
+  phrasing review. Floor, not ceiling.
+---
+
+# reviewing-artifacts
+
+One reviewer for every workflow artifact. It does not score against a fixed checklist
+or a published standard — it asks a few questions about whether the artifact does its
+job and fits this project, and trusts your judgment for the rest.
+
+**The questions are a floor, not a ceiling.** If something hurts the artifact and
+isn't listed below, flag it anyway.
+
+**Scope.** Review whatever artifact you're handed, *by kind* — commands, skills,
+READMEs, stories, CLAUDE.md, and anything like them. Don't tie this skill to a fixed
+inventory of the current commands and skills; new ones appear and old ones change. The
+fine-grained **look and words** of a human-read doc — the README, the prose in `docs/` —
+go to `reviewing-typography` (the look) + `reviewing-phrasing` (the words); this skill
+judges whether the artifact does its job (Q5 still asks whether a doc serves its reader).
+
+## The five questions
+
+Ask these of any artifact. The artifact's type shifts which ones bite hardest.
+
+1. **One clear job.** Can you say what this file is for in a sentence? Does everything
+   in it serve that one job? Flag sprawl (steps that wander off) and heavy overlap with
+   another artifact (could it merge, or go away?).
+2. **Complete.** Does it deliver that job end to end — no missing steps, placeholder
+   text, or dead instructions that produce nothing? A reader/agent should be able to act.
+3. **Goal, not frozen spec — and no hardcoding.** Does it state intent and leave room
+   where room belongs, instead of freezing a "how" that will drift? Flag stale paths or
+   filenames, magic values that should be derived, rigid step-by-step where a principle
+   would do, and references to tools or layouts that have moved.
+4. **Fits the project.** Does it match the conventions this project actually uses —
+   markdown as the source of truth, plus the tools and layout the repo relies on now —
+   rather than a stack it has moved past? Flag coupling to a tool or layout the project
+   has genuinely retired or relocated; an integration the project still uses, or a
+   deliberate adapter, is not a violation. Cross-references resolve to files that exist.
+5. **Right for its reader.** Agent-facing (commands, skills): unambiguous instructions
+   the agent can follow. Human-facing (README, story): reads like a person wrote it for
+   a person — clear, concrete, scannable.
+
+Where each type leans:
+
+| Artifact | Leans on |
+|----------|----------|
+| Command / skill | Q3 (no hardcoding), Q5 (agent can follow it) |
+| README / user doc | Q5 (reads for a human), Q1 (one clear job) |
+| Story | Q3 (goal, not spec) — this is what `dw-review-story` checks at the story stage |
+| CLAUDE.md | Q2/Q4 (matches the repo as it actually is — no orphaned references) |
+
+## Producer→review pairing (coverage pass)
+
+A standing rule (CLAUDE.md → "Review pairing"): every **producer** has a **paired
+review**. When the scope is the whole workflow — or any change that adds/edits a
+producer — run this coverage pass on top of the five questions.
+
+It is a **method, not a fixed list** — derive the producers and reviews from whatever
+units exist now; don't hardcode an inventory that will drift.
+
+1. **List the producers.** A producer is any unit that *creates, syncs, publishes, or
+   drafts a deliverable* — by name (`create-`, `sync-`, `publish-`, `draft-`, `init-`)
+   or by what it does (a producing gerund skill — a name like `planning-…`, `drafting-…`).
+2. **List the reviews.** Any unit whose job is to *check a result* — `*-review`,
+   `*-verify`, the `reviewing-*` skills, a typography/format audit.
+3. **Match each producer to the review that covers its output.** A pairing is real only
+   if some review actually inspects what that producer makes.
+4. **Flag the gaps.** Name every producer with **no** review covering its output — that
+   is a pairing violation. Note the missing review and where it would live.
+5. **Mark the exempt.** A producer that yields no outward deliverable to review —
+   internal scaffolding, a visual folded into an already-reviewed doc, an authoring
+   input, tooling logs — is **exempt**, not a gap. List it as exempt and say why.
+
+Report pairings as a small table and list the unpaired producers as findings:
+
+```
+Producer → Review
+<producer>           → <review>            ✓
+<producer>           → (none)              ✗  needs: <proposed review + home>
+<producer>           → (exempt)            —  <why it has no outward deliverable>
+```
+
+## Steps
+
+1. **Scope.** A single file, a folder, or "the files I just changed." Find where the
+   artifacts actually live in *this* repo — don't assume a fixed layout.
+2. **Read** the target(s).
+3. **Ask the five questions** of each. Checklists are a floor — note anything else that
+   weakens the artifact.
+4. **Pairing coverage pass** (when reviewing the workflow or a producer change) — run
+   the section above and report unpaired producers.
+5. **Report** (below).
+6. **Fix (if asked).** Smallest blast radius first: remove leaked hardcoding, fill gaps,
+   tighten wording. Structural changes — merging, splitting, or removing an artifact —
+   need explicit confirmation. Never delete an artifact without approval; flag it for
+   removal instead.
+
+## Report
+
+Per artifact, a short verdict and the specific findings — no numeric score.
+
+```
+<artifact path> — PASS | REVISE | CUT
+
+- [Q#] <finding, with line reference> → <smallest fix>
+```
+
+- **PASS** — does its job, fits the project, nothing leaked.
+- **REVISE** — specific, fixable findings (gaps, hardcoding, drift, readability).
+- **CUT** — duplicates another artifact or does nothing useful; propose removal (with approval).
+
+End with the path(s) reviewed and the suggested next step.

--- a/.claude/skills/reviewing-phrasing/SKILL.md
+++ b/.claude/skills/reviewing-phrasing/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: reviewing-phrasing
+description: |
+  Reviews the words of a human-read document — the README, the prose in docs/, or any
+  text written for a person rather than an agent — for whether the phrasing fits its
+  reader: leads with the point, stays brief, carries the right tone, and says the true
+  complete thing and only that. The words half of the human-read doc review
+  (reviewing-typography handles the look). Use when such a doc is written or updated and
+  is about to reach a reader. Judgment over checklist; floor, not ceiling.
+---
+
+# reviewing-phrasing
+
+One reviewer for the **words** of any document written for a person. Its partner
+`reviewing-typography` judges how a doc *looks*; this judges how it *reads*. Together
+they are the human-read doc review.
+
+This skill's job is **human-read** text — the README, the prose inside `docs/`, and any
+text aimed at a person. The **agent-read** workflow tooling — commands, skills, rules,
+CLAUDE.md, stories — is **not** this skill's job; whether those do their job goes to
+`reviewing-artifacts`.
+
+## Why this is a judgment skill, not a checklist
+
+Good phrasing can't be frozen into a rule. The sentence that's right in a quickstart is
+wrong in a design rationale; a line that lands for an engineer loses a newcomer. There is
+no fixed order and no score — read the doc as its **actual reader** would and decide what
+helps and what hurts. Use common sense.
+
+## What to weigh
+
+These are **lenses, not steps** — they interact, and which bites hardest depends on the
+doc in hand. Weigh them together, and flag anything that weakens the writing even if it
+isn't named here.
+
+- **Reader.** Who actually reads this, and what do they already know? The phrasing meets
+  them there — no unexplained jargon for a newcomer, no over-explaining to a peer.
+- **Lead with the point.** The reader should hit what matters first, not after a runway of
+  setup. Context that arrives before the point reads as not knowing the priority — or as
+  hiding something. Front-load the conclusion; let the detail follow for those who want it.
+- **Brevity.** Less is more. Every word earns its place; cut filler, hedging, and the
+  second sentence that restates the first. A reader skimming a long file rewards a doc that
+  respects their time.
+- **Content.** Does it say the true, complete thing the reader needs — and only that? No
+  vague filler, nothing burying the one fact that matters, no gap that forces the reader to
+  go ask the obvious. Brevity is not omission: precise, not contextless.
+- **Tone.** Does it fit the relationship and the moment? A quickstart, a caveat, and a
+  rationale each carry a different register.
+- **Purpose.** The doc exists to move one outcome — get someone set up, understood, or
+  unblocked. Do the words drive *that*, or wander off it?
+
+## The test
+
+When unsure whether a passage lands, read it as the reader would — or show it to someone
+who isn't in your head. Where they get lost or lose interest is where the words are
+redundant, buried, or missing a hook. That spot is the finding.
+
+## Steps
+
+1. **Scope.** Which doc(s), and who the reader is. If the reader isn't clear from the doc
+   or its context, ask before reviewing.
+2. **Read it as that reader would** — once, straight through, for whether it lands.
+3. **Weigh the lenses** above by judgment; note anything else that hurts the phrasing.
+4. **Report** (below).
+5. **Fix (if asked).** The smallest change that fixes the phrasing — keep the author's
+   voice, don't rewrite what already works, don't pad. A clean doc gets said so, with no
+   invented findings.
+
+## Report
+
+Per doc, a short verdict and specific findings — no numeric score.
+
+```
+<doc> — PASS | REVISE
+
+- <what hurts the phrasing, quoted> → <smallest fix>
+```
+
+- **PASS** — fits its reader, leads with the point, says the right thing.
+- **REVISE** — specific, fixable findings (buried point, padding, wrong register, missing fact).
+
+End with what was reviewed and the suggested next step.

--- a/.claude/skills/reviewing-typography/SKILL.md
+++ b/.claude/skills/reviewing-typography/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: reviewing-typography
+description: |
+  Reviews how a human-read document looks — the README, the prose and tables in docs/, or
+  any markdown written for a person — for visual hierarchy, Gestalt proximity, restraint,
+  and walls of text, so a reader can find the point at a glance. The look half of the
+  human-read doc review (reviewing-phrasing handles the words). Use when such a doc is
+  written or restructured. Judgment over checklist; floor, not ceiling.
+---
+
+# reviewing-typography
+
+One reviewer for how a human-read document **looks**. Its partner `reviewing-phrasing`
+judges how a doc *reads*; this judges how it *scans*. Together they are the human-read doc
+review.
+
+This skill's job is **human-read** markdown — the README, the prose, tables, and lists in
+`docs/`, and any doc aimed at a person. The **agent-read** workflow tooling — commands,
+skills, rules, CLAUDE.md, stories — is **not** this skill's job; whether those do their job
+goes to `reviewing-artifacts`.
+
+A markdown doc has no fonts to set, but it has the same levers UI typography uses, and the
+same principles decide whether it works: **heading levels** are size/weight, **blank lines
+and grouping** are spacing, **bold/italic** are weight, and **paragraph and list length**
+decide whether the page reads as structure or as soup.
+
+## Why this is a judgment skill, not a checklist
+
+The right structure depends on the content's actual shape, which no rule can predict. A
+metadata line reads fine until real prose lands under it and the two fuse. One bold label
+anchors the eye; ten bold labels compete and the hierarchy collapses. A 4-item list reads
+cleanly; a 17-item list reads as a paragraph. **Look at the doc and decide** — there is no
+rule set that survives contact with arbitrary content.
+
+## What to weigh
+
+These are **lenses, not steps**. Weigh them together; flag anything that weakens the look
+even if it isn't named here.
+
+- **Hierarchy.** Can the eye find the point of focus? A doc with no heading structure reads
+  as one undifferentiated blob — the reader has no idea what they're looking at. The title
+  and section heads should be visibly heavier than the body; each level distinct from the
+  next.
+- **Proximity (grouping).** Spacing groups or separates. Related lines sit together; a real
+  break — a blank line, a heading, a rule — sits between things that aren't one group.
+  Where ideas cross layers (metadata → prose, intro → first section) they need the loosest
+  separation, or they fuse.
+- **Restraint.** You need very few levels. A handful of heading depths plus weight is enough
+  to build any doc; piling on nested headings, or bolding every other phrase, *destroys*
+  hierarchy rather than adding it.
+- **Emphasis by de-emphasis.** To make something stand out, tone the rest down. If every
+  paragraph opens with a bold phrase, none of them anchor anything. Emphasis is a budget —
+  spend it on the few things the reader should land on.
+- **Wall of text.** A long undifferentiated paragraph, or an 800-word stretch with no
+  heading break, reads as soup. Break at the natural boundary; promote a `**Label:**`
+  followed by a long list into a real heading.
+- **Structure for the true shape, then for focus.** Use heading levels for the doc's real
+  hierarchy — but also use common sense about what the reader should focus on and let that
+  stand out. Don't structure for structure's sake; structure for whether the reader can
+  *use* the doc.
+
+## The test
+
+Squint at the rendered doc — or scan it without reading any word. The visible weight order
+(title → headings → emphasis → body) should be obvious at a glance. If you can't tell the
+levels apart unfocused, the hierarchy isn't doing its job. When unsure, show it to someone
+and watch where their eye snags or stalls; that spot is the finding.
+
+## Steps
+
+1. **Scope.** Which doc(s). If unclear, ask before reviewing.
+2. **Scan it as a reader would** — unfocused first (does the shape read?), then through.
+3. **Weigh the lenses** above by judgment; note anything else that hurts the look.
+4. **Report** (below).
+5. **Fix (if asked).** The smallest change that fixes the look — a heading break, a blank
+   line, removing bold from the labels that aren't anchors. Don't restructure what already
+   reads well; don't invent findings on a clean doc (it trains everyone to ignore the real
+   ones).
+
+## Report
+
+Per doc, a short verdict and specific findings — no numeric score.
+
+```
+<doc> — PASS | REVISE
+
+- <what hurts the look, with the location> → <smallest fix>
+```
+
+- **PASS** — the eye finds the point; hierarchy and grouping hold.
+- **REVISE** — specific, fixable findings (no hierarchy, fused groups, bold inflation, wall of text).
+
+End with what was reviewed and the suggested next step.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,82 +1,119 @@
-# TestLink MCP Server
+# CLAUDE.md
 
-## Project
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
 
-MCP server connecting Claude to TestLink test management. TypeScript, Node.js 20+, Docker.
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
 
-## Code Style
+## 1. Think Before Coding
 
-Fail fast, keep simple. See `.claude/skills/code-review/` for full guidelines.
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
 
-## Testing
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
 
-Integration tests under `cicd/tests/` form **one self-contained, connected end-to-end flow** — no hardcoded IDs, stable named fixtures, everything threaded and connected, with a unified teardown. Every added test must embed in the flow, never stand alone. See `.claude/skills/integration-test-flow/` for the principles and `cicd/tests/README.md` for the mechanics.
+## 2. Simplicity First
 
-## Agent Behavior Rules
+**Minimum code that solves the problem. Nothing speculative.**
 
-1. **Apply changes uniformly** — When modifying one file in a group (e.g., workflow files, config files), apply the same change to ALL files in that group. Do not skip files based on reasoning about whether they "need" it.
-2. **Do not assume future state** — Never justify skipping work by predicting what will or won't happen (e.g., "IDs will always be unique"). Apply the change, then flag concerns as separate issues.
-3. **Do not narrow scope without asking** — If the user says "fix all workflows", fix ALL workflows. Do not decide some don't need fixing.
-4. **Flag concerns separately** — If you spot a potential issue during implementation, finish the implementation first, then raise the concern as a separate issue or comment. Do not let concerns block or reduce the current work.
-5. **Consistency over optimization** — When in doubt, prefer consistent treatment across similar files over "smart" selective changes.
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
 
-## Dev Workflow
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
-### Commands
+## 3. Surgical Changes
 
-| Command | Purpose | Phase |
-|---------|---------|-------|
-| `/gh-init "<feature>"` | Create milestone + dev labels | Plan |
-| `/gh-track "<task>"` | Create issue under milestone with task checklist | Plan |
-| `/tl-define <issue#>` | Create test cases in TestLink for issue | Define |
-| `/gh-status "<feature>"` | Show open issues and pending tasks | Any |
-| `/gh-implement <issue#>` | Create branch, implement tasks, update checkboxes | Build |
-| `/gh-test <issue#>` | Build + run tests, report results to issue + TestLink | Verify |
-| `/gh-pr <issue#>` | Push branch, create PR with traceability | Deliver |
-| `/gh-merge <pr#>` | Merge PR, delete branch, close milestone if done | Deliver |
-| `/gh-close <issue#>` | Close issue with summary comment | Deliver |
-| `/evolve` | Analyze project history, suggest improvements | Any |
+**Touch only what you must. Clean up only your own mess.**
 
-### Lifecycle
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+## 5. Dev & QA workflow discipline
+
+Substantial work flows through a pipeline; each step is a gate that stops for a
+human decision (commands suggest the next, they never auto-run it):
 
 ```
-User Request
-  ├─► PLAN → TRACK → DEFINE → IMPLEMENT → TEST → PR → MERGE → NEXT
-  │
-  Rules:
-  - MERGE requires explicit user approval (NEVER auto-merge)
-  - Implement issues sequentially (one branch per issue)
-  - Commit messages include "refs #N"
-  - Check off task checkboxes as each completes
-  - PR body includes "Fixes #N" to auto-close issue
+dw-story → dw-review-story → dw-plan → [human reviews the plan issue]
+        → dw-tasks → dw-review-tasks → dw-implement → dw-review-implement
+        → dw-create-pr → [human review + /review] → dw-merge
 ```
 
-### Auto-Trigger Rules
+The full flow + producer→review pairing lives in `.claude/rules/dev-workflow.md`. Trivial
+work skips the plan: `dw-story → dw-tasks`.
 
-The agent advances automatically EXCEPT before merge:
-
-1. After user approves plan → `/gh-init` then `/gh-track`
-2. After tracking, if testable → `/tl-define`
-3. After test cases defined → `/gh-implement` first open issue
-4. After all checkboxes checked → `/gh-test`
-5. After tests pass → `/gh-pr`
-6. After PR created → **STOP** (merge is human decision)
-7. After user says merge → `/gh-merge`
-8. After merge → next issue or close milestone
-
-### Conventions
-
-- **Branches**: `<type>/<short-desc>-#<issue>` (types: feat, fix, refactor, docs, test)
-- **Issue titles**: `[<type>] <action description>`
-- **Labels**: feat, fix, refactor, docs, test + priority:high/med/low
-
-### Traceability
+**qa-workflow** is the sibling pipeline — same gated discipline, turning a story into
+trustworthy test docs:
 
 ```
-Milestone (user story)
-  └─► Issue #N (task checklist)
-       ├─► TestLink test cases (via /tl-define)
-       ├─► Branch + commits (refs #N)
-       ├─► PR (Fixes #N → auto-close)
-       └─► Test results (reported to issue + TestLink)
+qw-plan → qw-review-plan → qw-cases → qw-review-cases
 ```
+
+The full flow + pairing lives in `.claude/rules/qa-workflow.md`.
+
+Two review gates are external skills this toolkit does not own — invoke them by hand:
+- `code-review` (bundled): adversarial diff review. Run after `dw-implement`,
+  alongside `dw-review-implement`. Earns its cost on logic/risk; skip for pure docs.
+- `/review` (builtin): PR overview. Run after `dw-create-pr`, before `dw-merge`.
+
+Don't wire these into the `dw-*` commands — they may not exist in every install,
+and a command that references a missing skill is a dangling pointer.
+
+**Right-size it.** A typo or a one-line doc change does not need the full chain —
+use judgment; branch + PR + merge is enough. The three review passes overlap:
+`dw-review-implement` is the always-on substance gate, `code-review` is for real
+logic or risk, `/review` is the PR summary. Running all three on a trivial diff is
+ritual, not rigor.
+
+## 6. Artifact & doc review discipline
+
+Match the reviewer to **who reads** the file you changed:
+
+- **Human-read docs** (README, `docs/` prose): run `reviewing-phrasing` (the words)
+  + `reviewing-typography` (the look) — the human-read doc review.
+- **Agent-read tooling** (commands, skills, CLAUDE.md, rules): run
+  `reviewing-artifacts` (does it do its job — one job, complete, goal-not-spec,
+  fits the project, right for its reader).
+
+These are skills this project owns. Like the dev-workflow gates, they stop for a human
+and never auto-run — invoke them by hand.
+
+**Right-size it.** A typo or a one-line tweak does not need a review pass — use
+judgment. Reach for these when a change is substantial enough that the look, the
+wording, or the artifact's fitness actually matters.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/docs/stories/STORY-008.md
+++ b/docs/stories/STORY-008.md
@@ -47,3 +47,4 @@ other project built from the template.
 - Created: 2026-06-12
 - Plan: #69
 - Issues: #70
+- PR: #71 (open)

--- a/docs/stories/STORY-008.md
+++ b/docs/stories/STORY-008.md
@@ -1,0 +1,49 @@
+# STORY-008: Align .claude tooling with agent-workflows-runner
+
+## User Story
+
+As a maintainer of testlink-mcp,
+I want my `.claude/` skills and commands to match agent-workflows-runner,
+So that I get the qa-workflow and CI tooling the template has standardized on,
+instead of drifting on an older toolset.
+
+## The Need
+
+agent-workflows-runner (the renamed `test-framework-template`; local checkout still
+at `/home/jack/src/test-framework-template/.claude`) is the reference for how this
+family of projects should be set up. testlink-mcp is missing pieces the template
+now carries:
+
+- **qa-workflow commands** (`qw-plan`, `qw-cases`, `qw-bind`, `qw-drift`,
+  `qw-review-*`) — testlink-mcp has none of them.
+- **CI skills** (`ci-run`, `ci-testcase`) and supporting skills (`add-tool`,
+  `install`, the `review-*` family) — present in the template, absent here.
+- **rules** — the template carries `test-yaml-format.md` and
+  `workflow-patterns.md`; testlink-mcp only has `dev-workflow.md`.
+
+The maintainer should be able to use the same QA + CI commands here as in any
+other project built from the template.
+
+## Success Looks Like
+
+- The qa-workflow command set and the CI/support skills from the template are
+  available under testlink-mcp's `.claude/`.
+- Running a qa-workflow or CI command in testlink-mcp behaves the same as in the
+  template, adapted to this repo's layout (`cicd/tests/`, TestLink specifics).
+- Nothing testlink-mcp-specific (TestLink commands, existing dev-workflow) is lost
+  in the alignment.
+
+## Open Questions
+
+- Which template skills/commands apply verbatim vs. need adaptation for the
+  TestLink/MCP context? (worked out in the plan)
+- Are template `rules/` (`test-yaml-format.md`, `workflow-patterns.md`) adopted
+  as-is or merged with this repo's conventions?
+- How to reconcile testlink-mcp's existing `github/` (gh-*) commands with the
+  template's dev-workflow — keep both, replace, or bridge?
+
+## Status
+
+- Created: 2026-06-12
+- Plan: #69
+- Issues: #70

--- a/docs/stories/STORY-009.md
+++ b/docs/stories/STORY-009.md
@@ -1,0 +1,38 @@
+# STORY-009: Port latest Anthropic ideas into the project tooling
+
+## User Story
+
+As a maintainer of testlink-mcp,
+I want the project to adopt the latest Anthropic / Claude Code ideas already proven
+in agent-workflows-runner,
+So that the repo's automation stays current instead of falling behind newer patterns.
+
+## The Need
+
+agent-workflows-runner (renamed from `test-framework-template`) has moved ahead on
+how it uses Claude Code (workflow
+patterns, skills, CI conventions). testlink-mcp should pull those forward rather
+than maintain an older style. The specific ideas to port are not pinned down yet —
+the maintainer flagged this briefly and wants the *how* settled at plan time.
+
+## Success Looks Like
+
+- testlink-mcp's tooling reflects the current patterns the template uses, with no
+  obvious "this is the old way" gaps left behind.
+- The maintainer can point at the template and the repo and see them as the same
+  generation of tooling.
+
+## Open Questions
+
+- **Primary input for the plan: compare the CI between this project and the target
+  project (`agent-workflows-runner`).** The diff in CI setup is the concrete signal
+  for what "latest ideas" means here — start there.
+- Which differences are intentional (TestLink/MCP-specific) vs. drift to be closed?
+- Does this overlap with STORY-008 (align .claude) — and if so, where's the seam?
+- Scope: tooling/CI patterns only, or also model IDs, skill-authoring, and
+  multi-agent conventions?
+
+## Status
+
+- Created: 2026-06-12
+- Issues: none

--- a/docs/stories/STORY-010.md
+++ b/docs/stories/STORY-010.md
@@ -1,0 +1,41 @@
+# STORY-010: Apply test binding to existing tests
+
+## User Story
+
+As a QA engineer on testlink-mcp,
+I want each existing test to be bound to the executable that runs it (the qw-bind
+audit link),
+So that intent (the test doc) and execution (the cicd YAML) stay verifiably in sync
+instead of diverging silently.
+
+## The Need
+
+The template's qa-workflow treats binding as **audit, not codegen**: a markdown test
+doc owns *intent* (why / what), the cicd YAML owns *execution* (how it runs), and a
+link connects them — checked later by the binding's paired review.
+
+testlink-mcp already has a body of integration tests under `cicd/tests/` (the
+single connected end-to-end flow) but no binding layer over them. The maintainer
+wants the binding applied to what already exists, not just to new tests — so the
+existing suite gains the same traceability the template assumes.
+
+## Success Looks Like
+
+- Every existing test case has a binding linking its intent doc to the cicd YAML
+  that executes it.
+- Running the binding's paired review (`qw-review-bind` / `qw-drift`) over the
+  existing suite passes — the links hold.
+- No existing test behavior changes; this adds traceability, not new execution.
+
+## Open Questions
+
+- Forward bind (doc → YAML) or revert (port existing YAML into a doc scaffold), or
+  a mix? The existing tests have YAML but may lack `docs/tests/TS-*.md` docs.
+- Depends on STORY-008 landing the qa-workflow commands first.
+- How does binding coexist with this repo's "one self-contained connected flow"
+  integration-test principle?
+
+## Status
+
+- Created: 2026-06-12
+- Issues: none

--- a/docs/stories/STORY-011.md
+++ b/docs/stories/STORY-011.md
@@ -1,0 +1,42 @@
+# STORY-011: Review all TestLink-related commands and skills
+
+## User Story
+
+As a maintainer of testlink-mcp,
+I want a total review of the TestLink-related commands and skills,
+So that the TestLink tooling is accurate, consistent, and not stale or duplicated
+after the template alignment.
+
+## The Need
+
+testlink-mcp carries a large TestLink-specific surface that the template does not:
+
+- ~20 `tl-*` commands under `.claude/commands/testlink/` (create/list/update/get
+  cases, suites, plans, executions, requirements, sync, format, identify-type).
+- TestLink-specific skills (`syncing-testlink`, `integration-test-flow`) and the
+  `github/` `tl-define` command.
+
+These grew over time and have not been reviewed as a whole. As STORY-008/009 pull
+in template patterns, the TestLink commands need a pass to confirm they're correct,
+consistent with each other, free of overlap/dead entries, and aligned with the new
+qa-workflow conventions.
+
+## Success Looks Like
+
+- Every TestLink command and skill is reviewed and its status known: keep / fix /
+  merge / retire.
+- Naming, structure, and conventions are consistent across the `tl-*` set and with
+  the adopted template patterns.
+- Redundant, broken, or outdated TestLink tooling is identified (and addressed).
+
+## Open Questions
+
+- Best done after STORY-008/009 so the review measures against the new conventions?
+- Which `tl-*` commands overlap with the underlying MCP tools vs. add real value?
+- Does any TestLink command belong in the qa-workflow rather than a standalone
+  `tl-*` namespace?
+
+## Status
+
+- Created: 2026-06-12
+- Issues: none

--- a/docs/stories/STORY-012.md
+++ b/docs/stories/STORY-012.md
@@ -1,0 +1,43 @@
+# STORY-012: Review and prune non-TestLink local-only .claude tooling
+
+## User Story
+
+As a maintainer of testlink-mcp,
+I want the local-only `.claude` tooling that isn't TestLink-specific reviewed and
+mostly removed,
+So that the repo carries only the tooling it actually uses, instead of accreted
+commands and skills that overlap with the agent-workflows-runner baseline.
+
+## The Need
+
+A diff against agent-workflows-runner shows 34 files that exist only in this repo's
+`.claude/`. The TestLink commands and skills among them are handled by STORY-011.
+The **rest** — github `gh-*` commands, `utility/evolve`, the extra `dw-review-pr`
+command, and the non-TestLink local skills (`code-review`, `integration-test-flow`,
+`tracking-changes`) — grew over time and were never reviewed as a set. The
+maintainer's read is that most of these should be reviewed and removed: they
+predate the qa-workflow / CI alignment (STORY-008) and likely overlap with it or
+are no longer earning their place.
+
+## Success Looks Like
+
+- Every non-TestLink local-only command and skill has a known verdict: keep / merge
+  into the aligned tooling / remove.
+- What's removed is genuinely unused or superseded — nothing the repo still depends
+  on is dropped.
+- What remains is consistent with the aligned tooling from STORY-008.
+
+## Open Questions
+
+- Where exactly is the TestLink boundary? `github/tl-define` and `syncing-testlink`
+  are TestLink-related (STORY-011); confirm the partition so nothing falls between
+  the two stories.
+- Does the `github/` `gh-*` set get removed in favour of the dev-workflow / GitHub
+  flow the template uses, or is it still load-bearing for this repo?
+- Best sequenced after STORY-008 lands, so "overlaps with the aligned tooling" is a
+  real comparison rather than a prediction.
+
+## Status
+
+- Created: 2026-06-12
+- Issues: none


### PR DESCRIPTION
## Summary
- Port the qa-workflow commands, CI/support skills (`ci-run`, `ci-testcase`, `add-tool`, `install`), `reviewing-*` skills, and rules (`test-yaml-format` with `testlink_id`, `workflow-patterns`) from agent-workflows-runner — `review-docs-privacy` excluded per maintainer.
- Bring the three drifted shared dev-workflow files back in sync with upstream.
- Replace project `CLAUDE.md` with the `ai-qa-workflow` template and add `.claude/rules/qa-workflow.md` it references.
- Add planning stories STORY-008 through STORY-012.

Fixes #70
Part of STORY-008 · plan #69

## Test plan
- [ ] 7 `qw-*` commands resolve under `.claude/commands/qa-workflow/`
- [ ] `ci-run` / `ci-testcase` invocations match this repo's `cicd/tests/` runner
- [ ] All `.claude` cross-references and CLAUDE.md §5's `qa-workflow.md` reference resolve
- [ ] No existing `tl-*` / `gh-*` command or local skill lost

Generated with [Claude Code](https://claude.com/claude-code)