### PR TITLE
Port the LLM judge to the Anthropic SDK

### DIFF
--- a/cicd/tests/package-lock.json
+++ b/cicd/tests/package-lock.json
@@ -8,8 +8,8 @@
       "name": "test-framework",
       "version": "1.0.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.102.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "axios": "^1.7.2",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
         "glob": "^10.3.10",
@@ -23,6 +23,36 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.102.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.102.0.tgz",
+      "integrity": "sha512-cThh3KcPW3lzkFyTz1cjyhJvOVw45NkLMoowO2ZJ/76CBz44ADUon+NsjEc/PypAkARs72Xu8qxTnx6PAOTQUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -546,6 +576,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
@@ -664,23 +700,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -788,18 +807,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
@@ -897,15 +904,6 @@
         }
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -981,21 +979,6 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1171,6 +1154,12 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -1208,26 +1197,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -1242,22 +1211,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -1397,21 +1350,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -1429,7 +1367,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
       "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1551,6 +1488,19 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -1597,27 +1547,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -1772,12 +1701,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.0",
@@ -2040,6 +1963,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2153,6 +2086,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -2369,7 +2308,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/cicd/tests/package.json
+++ b/cicd/tests/package.json
@@ -18,8 +18,8 @@
     "dev": "tsx src/cli.ts"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.102.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "axios": "^1.7.2",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
     "glob": "^10.3.10",

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -33,9 +33,6 @@ program
   .option('-s, --suite <suite>', 'Run only tests from this suite')
   .option('-i, --id <id>', 'Run only the test with this ID')
   .option('--dry-run', 'Show what would run without executing', false)
-  .option('--llm', 'Enable LLM judging (simple judge only by default)', false)
-  .option('--judge-url <url>', 'Ollama URL for LLM judge', CONFIG.llm.defaultUrl)
-  .option('--judge-model <model>', 'Model to use for LLM judging', CONFIG.llm.defaultModel)
   .option('-o, --output-dir <dir>', 'Output directory for results')
   .option('-f, --format <format>', 'Output format (console, json)', 'console')
   .action(async (options) => {
@@ -60,9 +57,7 @@ program
       suite: options.suite,
       testId: options.id,
       dryRun: options.dryRun,
-      noLlm: !options.llm,
-      judgeUrl: options.judgeUrl,
-      judgeModel: options.judgeModel,
+      dualMode: CONFIG.llm.mode === 'dual',
       outputDir,
       outputFormat: options.format as RunConfig['outputFormat'],
       workingDir: projectRoot,
@@ -73,7 +68,7 @@ program
     process.stderr.write(`[CONFIG] Docker compose: ${dockerDir}\n`);
     process.stderr.write(`[CONFIG] Testcases: ${testcasesDir}\n`);
     process.stderr.write(`[CONFIG] Output: ${outputDir}\n`);
-    process.stderr.write(`[CONFIG] LLM Judge: ${config.noLlm ? 'disabled' : config.judgeUrl}\n`);
+    process.stderr.write(`[CONFIG] LLM Judge: ${config.dualMode ? `dual (${CONFIG.llm.baseUrl || 'Anthropic API'}, ${CONFIG.llm.model})` : 'simple only'}\n`);
 
     // Load test cases
     const loader = new TestLoader(testcasesDir);
@@ -138,19 +133,18 @@ program
 
     let llmJudgments = simpleJudgments.map((j) => ({
       ...j,
-      reason: config.noLlm ? 'LLM judge disabled' : j.reason,
+      reason: config.dualMode ? j.reason : 'LLM judge disabled (simple mode)',
     }));
 
-    if (!config.noLlm) {
+    if (config.dualMode) {
       process.stderr.write('[JUDGE] Running LLM judge...\n');
-      const llmJudge = new LLMJudge(config.judgeUrl, config.judgeModel);
+      const llmJudge = new LLMJudge();
 
       const available = await llmJudge.isAvailable();
       if (available) {
         llmJudgments = await llmJudge.judgeResults(results);
-        await llmJudge.unloadModel();
       } else {
-        process.stderr.write('[WARN] LLM judge not available, using simple judge results\n');
+        process.stderr.write('[WARN] LLM judge endpoint unreachable, falling back to simple judge results\n');
       }
     }
 

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -26,8 +26,15 @@ export const CONFIG = {
   
   // LLM Judge defaults
   llm: {
-    defaultUrl: 'http://192.168.6.113:11435',
-    defaultModel: 'gemma3:12b-judge',
+    // 'simple' (default) = deterministic checks only. 'dual' = also run the LLM judge.
+    mode: process.env.LLM_JUDGE_MODE || 'simple',
+    // Optional base URL for any Anthropic-compatible endpoint (hosted or local).
+    // Unset → the Anthropic SDK's default endpoint.
+    baseUrl: process.env.LLM_JUDGE_URL || undefined,
+    // Real key for hosted Anthropic; a placeholder is fine for a local endpoint
+    // that ignores auth.
+    apiKey: process.env.ANTHROPIC_API_KEY || 'local',
+    model: process.env.LLM_JUDGE_MODEL || 'claude-haiku-4-5-20251001',
     timeout: 300000,
     stdoutLimit: 1000,
     stderrLimit: 500,

--- a/cicd/tests/src/judge/llm-judge.ts
+++ b/cicd/tests/src/judge/llm-judge.ts
@@ -1,36 +1,50 @@
 /**
- * LLM Judge - Semantic analysis of test results using Ollama.
+ * LLM Judge - Semantic analysis of test results via the Anthropic SDK.
  *
  * Uses a language model to evaluate test execution logs against criteria.
  * Catches silent failures that exit code checking misses.
  *
- * Judges one test at a time with structured JSON prompts and Ollama JSON mode
- * for reliable parsing. Includes observability logging for debugging CI failures.
+ * Reaches its model through the standard Anthropic client, so any
+ * Anthropic-compatible endpoint (hosted or a local one) is a matter of
+ * configuration (LLM_JUDGE_URL / LLM_JUDGE_MODEL / ANTHROPIC_API_KEY), not a
+ * code change. Judges one test at a time with a structured JSON prompt.
  */
 
-import axios from 'axios';
+import Anthropic from '@anthropic-ai/sdk';
 import { TestResult, Judgment } from '../types.js';
 import { CONFIG } from '../config.js';
 
 export class LLMJudge {
-  private ollamaUrl: string;
+  private client: Anthropic;
   private model: string;
 
   constructor(
-    ollamaUrl: string = CONFIG.llm.defaultUrl,
-    model: string = CONFIG.llm.defaultModel
+    baseUrl: string | undefined = CONFIG.llm.baseUrl,
+    model: string = CONFIG.llm.model,
+    apiKey: string = CONFIG.llm.apiKey
   ) {
-    this.ollamaUrl = ollamaUrl;
+    this.client = new Anthropic({
+      apiKey,
+      baseURL: baseUrl,
+      timeout: CONFIG.llm.timeout,
+    });
     this.model = model;
   }
 
+  /**
+   * Probe the configured endpoint. Returns false on any connection/auth error
+   * so the caller can skip cleanly and fall back to the simple judge.
+   */
   async isAvailable(): Promise<boolean> {
     try {
-      const response = await axios.get(`${this.ollamaUrl}/api/tags`, {
-        timeout: 5000,
+      await this.client.messages.create({
+        model: this.model,
+        max_tokens: 1,
+        messages: [{ role: 'user', content: 'ping' }],
       });
-      return response.status === 200;
-    } catch {
+      return true;
+    } catch (error) {
+      process.stderr.write(`  [LLM] Endpoint not reachable: ${error}\n`);
       return false;
     }
   }
@@ -83,12 +97,12 @@ export class LLMJudge {
       steps,
       container_logs: this.truncate(r.logs, CONFIG.llm.logsLimit),
       respond: {
-        format: 'Respond with a single JSON object',
+        format: 'Respond with a single JSON object and nothing else',
         fields: {
           testId: r.testCase.id,
-          pass: 'boolean — true or false',
-          reason: 'Brief explanation referencing each criterion',
-          evidence: 'Optional — quote the exact stdout/stderr/log content that supports your verdict if available',
+          pass: 'true if test meets all criteria, false otherwise',
+          reason: 'Brief explanation of your verdict',
+          evidence: 'Required if pass is false — the exact stdout content or log line that caused failure',
         },
       },
     };
@@ -105,33 +119,34 @@ export class LLMJudge {
   }
 
   /**
+   * Extract the first JSON object from a model response, tolerating prose or
+   * markdown fences around it.
+   */
+  private extractJson(text: string): string | null {
+    const start = text.indexOf('{');
+    const end = text.lastIndexOf('}');
+    if (start === -1 || end === -1 || end < start) return null;
+    return text.substring(start, end + 1);
+  }
+
+  /**
    * Judge a single test result.
    */
   private async judgeOne(result: TestResult): Promise<Judgment> {
     const prompt = this.buildPrompt(result);
     const testId = result.testCase.id;
 
-    const response = await axios.post(
-      `${this.ollamaUrl}/api/generate`,
-      {
-        model: this.model,
-        prompt,
-        stream: false,
-        format: 'json',
-        options: {
-          temperature: 0.1,
-          num_predict: 1024,
-        },
-      },
-      {
-        timeout: CONFIG.llm.timeout,
-      }
-    );
+    const response = await this.client.messages.create({
+      model: this.model,
+      max_tokens: 1024,
+      temperature: 0.1,
+      messages: [{ role: 'user', content: prompt }],
+    });
 
-    const responseText = response.data.response;
-    const promptTokens = response.data.prompt_eval_count ?? '?';
-    const responseTokens = response.data.eval_count ?? '?';
-    process.stderr.write(`  [LLM] Tokens for ${testId}: prompt=${promptTokens}, response=${responseTokens}\n`);
+    const textBlock = response.content.find((b) => b.type === 'text');
+    const responseText = textBlock && textBlock.type === 'text' ? textBlock.text : '';
+
+    process.stderr.write(`  [LLM] Tokens for ${testId}: prompt=${response.usage.input_tokens}, response=${response.usage.output_tokens}\n`);
 
     // Handle empty response
     if (!responseText) {
@@ -145,8 +160,18 @@ export class LLMJudge {
 
     process.stderr.write(`  [LLM] Raw response for ${testId} (${responseText.length} chars): ${responseText.substring(0, 500)}\n`);
 
+    const json = this.extractJson(responseText);
+    if (!json) {
+      process.stderr.write(`  [LLM] WARNING: No JSON object in response for ${testId}\n`);
+      return {
+        testId,
+        pass: false,
+        reason: `No JSON object in LLM response: ${responseText.substring(0, 200)}`,
+      };
+    }
+
     try {
-      const judgment = JSON.parse(responseText) as Judgment;
+      const judgment = JSON.parse(json) as Judgment;
 
       // Validate testId matches
       if (judgment.testId !== testId) {
@@ -212,24 +237,5 @@ export class LLMJudge {
     }
 
     return allJudgments;
-  }
-
-  async unloadModel(): Promise<void> {
-    try {
-      process.stderr.write(`  [LLM] Unloading judge model ${this.model}...\n`);
-      await axios.post(
-        `${this.ollamaUrl}/api/generate`,
-        {
-          model: this.model,
-          keep_alive: 0,
-        },
-        {
-          timeout: 30000,
-        }
-      );
-      process.stderr.write(`  [LLM] Judge model unloaded.\n`);
-    } catch {
-      process.stderr.write(`  [LLM] Warning: Failed to unload judge model\n`);
-    }
   }
 }

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -221,12 +221,8 @@ export interface RunConfig {
   testId?: string;
   /** Show what would run without executing */
   dryRun: boolean;
-  /** Skip LLM judging (simple judge only) */
-  noLlm: boolean;
-  /** URL of the LLM judge Ollama instance */
-  judgeUrl: string;
-  /** Model to use for LLM judging */
-  judgeModel: string;
+  /** Run the LLM judge in addition to the simple judge (LLM_JUDGE_MODE=dual) */
+  dualMode: boolean;
   /** Output directory for results */
   outputDir: string;
   /** Output format */
@@ -242,8 +238,6 @@ export interface RunConfig {
  */
 export const DEFAULT_CONFIG: Partial<RunConfig> = {
   dryRun: false,
-  noLlm: true,
-  judgeUrl: 'http://localhost:11434',
-  judgeModel: 'llama3:8b',
+  dualMode: false,
   outputFormat: 'console',
 };

--- a/docs/stories/STORY-009.md
+++ b/docs/stories/STORY-009.md
@@ -38,4 +38,4 @@ port, not a CI overhaul.
 
 - Created: 2026-06-12
 - Plan: #82
-- Issues: #83, #84
+- Issues: #83 (PR #85 open), #84


### PR DESCRIPTION
## Summary
- Port the cicd test runner's opt-in LLM judge from Ollama/`axios` to the **Anthropic SDK** (`@anthropic-ai/sdk`), matching `agent-workflows-runner`.
- `config.ts` llm block is env-driven: `LLM_JUDGE_MODE` (simple|dual), `LLM_JUDGE_URL` (any Anthropic-compatible endpoint), `ANTHROPIC_API_KEY`, `LLM_JUDGE_MODEL` (default `claude-haiku-4-5-20251001`).
- `cli.ts` gates the LLM judge on `LLM_JUDGE_MODE=dual` (matching the `ci-run` skill) and drops the Ollama-specific `--llm`/`--judge-url`/`--judge-model` flags + `unloadModel`; `RunConfig` `noLlm/judgeUrl/judgeModel` → `dualMode`.
- The deterministic **simple judge stays the default** — normal runs are unchanged.

Fixes #83
Part of STORY-009 · plan #82

## Test plan / verification
- [x] `tsc --noEmit` clean; no leftover refs to removed config keys; `axios` out, `@anthropic-ai/sdk` in
- [x] Default (simple) suite **19/19 green** against a live TestLink — existing tests unchanged
- [x] `LLM_JUDGE_MODE=dual` invokes the Anthropic API via the SDK (verified: real `401` with the `'local'` placeholder key) and falls back to the simple judge cleanly when no key is present
- [ ] With a real `ANTHROPIC_API_KEY`, dual mode judges via Claude (needs the secret — see #84)

## Notes
- Follow-up **#84** (decision-gated): wire `ANTHROPIC_API_KEY` into CI *if* the team wants the dual judge to run there; otherwise CI stays on the simple judge and dual is a local opt-in.

Generated with [Claude Code](https://claude.com/claude-code)
