### PR TITLE
Fix TC-S1-002 false positive + un-orphan CI judge wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,6 @@ on:
         options:
           - "simple"
           - "dual"
-      judge_model:
-        description: "LLM model for judging (if dual mode)"
-        required: false
-        default: "gemma3:12b-judge"
-        type: string
       test_id:
         description: "Run a single test by ID (e.g., TC-S1-001)"
         required: false
@@ -28,6 +23,5 @@ jobs:
     with:
       suite: s1-build-deploy
       judge_mode: ${{ inputs.judge_mode }}
-      judge_model: ${{ inputs.judge_model }}
       test_id: ${{ inputs.test_id }}
     secrets: inherit

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,11 +11,6 @@ on:
         options:
           - "simple"
           - "dual"
-      judge_model:
-        description: "LLM model for judging (if dual mode)"
-        required: false
-        default: "gemma3:12b-judge"
-        type: string
       test_id:
         description: "Run a single test by ID (e.g., TC-S1-001)"
         required: false
@@ -28,7 +23,6 @@ jobs:
     with:
       suite: s1-build-deploy
       judge_mode: ${{ inputs.judge_mode }}
-      judge_model: ${{ inputs.judge_model }}
       test_id: ${{ inputs.test_id }}
     secrets: inherit
 

--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -11,11 +11,6 @@ on:
         options:
           - "simple"
           - "dual"
-      judge_model:
-        description: "LLM model for judging (if dual mode)"
-        required: false
-        default: "gemma3:12b-judge"
-        type: string
       test_id:
         description: "Run a single test by ID (e.g., TC-S1-001)"
         required: false
@@ -28,7 +23,6 @@ jobs:
     with:
       suite: s1-build-deploy
       judge_mode: ${{ inputs.judge_mode }}
-      judge_model: ${{ inputs.judge_model }}
       test_id: ${{ inputs.test_id }}
     secrets: inherit
 
@@ -39,7 +33,6 @@ jobs:
     with:
       suite: s2-test-case
       judge_mode: ${{ inputs.judge_mode }}
-      judge_model: ${{ inputs.judge_model }}
       test_id: ${{ inputs.test_id }}
     secrets: inherit
 
@@ -50,7 +43,6 @@ jobs:
     with:
       suite: s3-test-suite
       judge_mode: ${{ inputs.judge_mode }}
-      judge_model: ${{ inputs.judge_model }}
       test_id: ${{ inputs.test_id }}
     secrets: inherit
 
@@ -61,7 +53,6 @@ jobs:
     with:
       suite: s4-test-plan
       judge_mode: ${{ inputs.judge_mode }}
-      judge_model: ${{ inputs.judge_model }}
       test_id: ${{ inputs.test_id }}
     secrets: inherit
 
@@ -72,7 +63,6 @@ jobs:
     with:
       suite: s5-build-mgmt
       judge_mode: ${{ inputs.judge_mode }}
-      judge_model: ${{ inputs.judge_model }}
       test_id: ${{ inputs.test_id }}
     secrets: inherit
 
@@ -83,6 +73,5 @@ jobs:
     with:
       suite: s7-requirements
       judge_mode: ${{ inputs.judge_mode }}
-      judge_model: ${{ inputs.judge_model }}
       test_id: ${{ inputs.test_id }}
     secrets: inherit

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -17,18 +17,13 @@ on:
           - "s7-requirements"
           - "all"
       judge_mode:
-        description: "Test judge mode"
+        description: "Test judge mode (dual needs CLAUDE_CODE_OAUTH_TOKEN; else falls back to simple)"
         required: false
         default: "simple"
         type: choice
         options:
           - "simple"
           - "dual"
-      judge_model:
-        description: "LLM model for judging (if dual mode)"
-        required: false
-        default: "gemma3:12b-judge"
-        type: string
       test_id:
         description: "Run a single test by ID (e.g., TC-S1-001)"
         required: false
@@ -43,11 +38,6 @@ on:
         description: "Test judge mode (simple, dual)"
         required: false
         default: "simple"
-        type: string
-      judge_model:
-        description: "LLM model for judging"
-        required: false
-        default: "gemma3:12b-judge"
         type: string
       test_id:
         description: "Run a single test by ID"
@@ -82,15 +72,13 @@ jobs:
         env:
           TESTLINK_URL: ${{ secrets.TESTLINK_URL }}
           TESTLINK_API_KEY: ${{ secrets.TESTLINK_API_KEY }}
-          OLLAMA_URL: ${{ secrets.OLLAMA_URL }}
+          # Judge mode is an env var, not a CLI flag. 'dual' opts in the agent judge,
+          # which authenticates keyless via the token below; if the secret is unset
+          # the agent judge is unreachable and the run falls back to the simple judge.
+          JUDGE_MODE: ${{ inputs.judge_mode || 'simple' }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           cd cicd/tests
-
-          # Build judge flags based on input (simple judge is the default; LLM is opt-in)
-          JUDGE_FLAGS=""
-          if [ "${{ inputs.judge_mode }}" = "dual" ]; then
-            JUDGE_FLAGS="--llm --judge-model ${{ inputs.judge_model || 'llama3:8b' }}"
-          fi
 
           # Build suite flag
           SUITE_FLAG=""
@@ -106,11 +94,10 @@ jobs:
 
           echo "Suite: ${{ inputs.suite }}"
           echo "Test ID: ${{ inputs.test_id || 'all' }}"
-          echo "Judge mode: ${{ inputs.judge_mode || 'dual' }}"
-          echo "Judge flags: $JUDGE_FLAGS"
+          echo "Judge mode: ${{ inputs.judge_mode || 'simple' }}"
 
-          # Run tests with JSON output
-          npx tsx src/cli.ts run $SUITE_FLAG $ID_FLAG $JUDGE_FLAGS --format json > /tmp/test-results.json || true
+          # Run tests with JSON output (judge mode via JUDGE_MODE env)
+          npx tsx src/cli.ts run $SUITE_FLAG $ID_FLAG --format json > /tmp/test-results.json || true
 
           echo "--- JSON Results ---"
           cat /tmp/test-results.json

--- a/cicd/tests/testcases/s1-build-deploy/TC-S1-002.yml
+++ b/cicd/tests/testcases/s1-build-deploy/TC-S1-002.yml
@@ -8,8 +8,11 @@ dependencies:
   - TC-S1-001
 
 steps:
-  - name: Verify server exits cleanly without API key
-    command: "timeout 5 node dist/index.js 2>&1; test $? -ne 0 && echo 'EXIT_OK: server requires API key'"
+  - name: Verify server self-exits when API key missing (not a timeout kill)
+    # Must unset TESTLINK_API_KEY — the suite exports it, so without `env -u` the
+    # server starts and hangs on stdin until `timeout` kills it (exit 124), which
+    # would falsely "pass". Require a real self-exit: non-zero AND not 124 (#90).
+    command: "env -u TESTLINK_API_KEY timeout 5 node dist/index.js 2>&1; code=$?; test $code -ne 0 && test $code -ne 124 && echo 'EXIT_OK: server self-exited without API key'"
     expectPatterns:
       - "EXIT_OK"
 
@@ -21,5 +24,6 @@ steps:
 
 criteria: |
   Verify MCP server behaves correctly:
-  - Server exits with non-zero when TESTLINK_API_KEY is missing
+  - Server self-exits non-zero (on its own, not killed by timeout) when
+    TESTLINK_API_KEY is missing
   - dist/index.js is a valid ES module entry point

--- a/cicd/tests/testcases/s1-build-deploy/TC-S1-002.yml
+++ b/cicd/tests/testcases/s1-build-deploy/TC-S1-002.yml
@@ -8,11 +8,14 @@ dependencies:
   - TC-S1-001
 
 steps:
-  - name: Verify server self-exits when API key missing (not a timeout kill)
+  - name: Verify server self-exits (exit 1) when API key missing
     # Must unset TESTLINK_API_KEY — the suite exports it, so without `env -u` the
     # server starts and hangs on stdin until `timeout` kills it (exit 124), which
-    # would falsely "pass". Require a real self-exit: non-zero AND not 124 (#90).
-    command: "env -u TESTLINK_API_KEY timeout 5 node dist/index.js 2>&1; code=$?; test $code -ne 0 && test $code -ne 124 && echo 'EXIT_OK: server self-exited without API key'"
+    # would falsely "pass". The server's guard is `process.exit(1)`, so require
+    # exactly 1: that rejects a timeout kill (124) and a missing-node error (127),
+    # pinning the documented missing-key contract (#90). dist validity is covered
+    # by TC-S1-001 (build) + the next step's `node --check`.
+    command: "env -u TESTLINK_API_KEY timeout 5 node dist/index.js; test $? -eq 1 && echo 'EXIT_OK: server self-exited (code 1) without API key'"
     expectPatterns:
       - "EXIT_OK"
 
@@ -24,6 +27,6 @@ steps:
 
 criteria: |
   Verify MCP server behaves correctly:
-  - Server self-exits non-zero (on its own, not killed by timeout) when
+  - Server self-exits with code 1 (its own guard, not killed by timeout) when
     TESTLINK_API_KEY is missing
   - dist/index.js is a valid ES module entry point

--- a/docs/stories/STORY-009.md
+++ b/docs/stories/STORY-009.md
@@ -43,7 +43,7 @@ to the judge, not a CI overhaul.
 - Created: 2026-06-12
 - Plan: #86 (judge = ACP client; supersedes the stale Anthropic-SDK plan #82, now closed)
 - Tasks (from #86): #87 (core — ACP-client judge + rename) — ✅ **done, PR #92 merged**; #88 (add-a-model-by-config proof), #89 (docs + prune/rename skills) — ✅ **done, PR #93 merged**
-- Follow-ups surfaced by #87: #90 (TC-S1-002 false positive the agent judge caught), #91 (CI test-suite.yml orphaned by the rewrite)
+- Follow-ups surfaced by #87: #90 (TC-S1-002 false positive the agent judge caught), #91 (CI test-suite.yml orphaned by the rewrite) — both **PR #94 open**
 - Earlier issues: #83 (done — PR #85 merged, raw @anthropic-ai/sdk, to be removed by #87),
   #84 (closed — CI key, moot under keyless ACP)
 - #86 is **planned** as **judge = ACP client (Option A)**: the reasoning judge becomes an


### PR DESCRIPTION
## Summary
Two STORY-009 follow-up fixes the agent judge surfaced, on one branch:

- **#90 — TC-S1-002 false positive.** The "server exits when API key missing" step never unset the key, so under a full-suite run the server started, hung, and was killed by `timeout` (exit 124) — an accidental pass. Now: `env -u TESTLINK_API_KEY` + require exit **exactly 1** (the server's `process.exit(1)` guard), which rejects a timeout kill (124) and node-missing (127). Dropped the vestigial `2>&1` (the server prints nothing on that path).
- **#91 — CI judge orphaned by the ACP rewrite.** `test-suite.yml` drove dual via non-existent `--llm --judge-model` flags + `OLLAMA_URL`. Now judge mode flows via the `JUDGE_MODE` env var; `dual` authenticates keyless via `CLAUDE_CODE_OAUTH_TOKEN` (falls back to the simple judge per-result if the secret is unset). Removed the dead `judge_model` input from `test-suite.yml` **and its callers** (`ci.yml`, `docker-publish.yml`, `test-pipeline.yml` ×7) so the reusable-workflow calls stay valid.

Fixes #90
Fixes #91
Part of STORY-009

## Test plan
- [x] TC-S1-002 passes both judges in dual mode (the agent judge, which failed it before, now passes — citing the 132ms duration ruling out a timeout kill)
- [x] **Full suite dual mode, keyless: 19/19 both judges** (was agent 18/19)
- [x] All five workflows valid YAML; no `judge_model`/`OLLAMA`/`--llm`/`LLM_JUDGE` refs remain; callers pass only valid inputs
- [x] Code-review caught + fixed a self-inflicted caller breakage (callers passing the removed input) before this PR
- [ ] Human review

## Notes
After this merges, STORY-009 is complete and the plan #86 can close.

Generated with [Claude Code](https://claude.com/claude-code)