### PR TITLE
Make testlink-* skills user-reusable + add their binding rule

### DIFF
--- a/.claude/rules/testlink-authoring.md
+++ b/.claude/rules/testlink-authoring.md
@@ -1,0 +1,45 @@
+---
+paths:
+  - ".claude/skills/testlink-format/**"
+  - ".claude/skills/testlink-review/**"
+  - ".claude/skills/testlink-sync/**"
+---
+
+# testlink-authoring
+
+The three `testlink-*` skills that turn a **source document** into **trustworthy
+TestLink content**. Same producer → review discipline as `dev-workflow` and
+`qa-workflow`: nothing is written without a pass that reads it back.
+
+## The flow
+
+```
+   a source document — a spec, a GitHub issue, a docs/tests/TS-*.md (or a folder of them)
+            │
+            ▼
+   testlink-sync ──────► testlink-review    create/update the entities the doc implies;
+            │                                 then read them back — PASS / FIX
+            │  (every rich-text field)
+            ▼
+   testlink-format                          the HTML markup contract both rely on
+```
+
+## Producer → review pairing
+
+| Producer | Review | Covers |
+|----------|--------|--------|
+| `testlink-sync` | `testlink-review` | the write met the goal — entities exist, fields correct and well-formed, faithful to the source |
+
+`testlink-format` is neither — it is the **shared reference**: TestLink rich-text
+fields are HTML, so both skills format field bodies through it. No producer ships
+without a review covering its output.
+
+## What this is — and where it sits
+
+- **Owns:** pushing a document *into* TestLink (requirements, suites, cases, plans,
+  builds) and verifying it landed. The document is the source of truth; TestLink is
+  brought into line with it.
+- **Upstream:** `qa-workflow` authors the `docs/tests/*.md` this can consume — but any
+  document that describes test intent is a valid source.
+- **Not this:** `testlink-mcp-code` is for changing the MCP **server** code — a
+  different concern, not part of the authoring triad.

--- a/.claude/skills/testlink-format/SKILL.md
+++ b/.claude/skills/testlink-format/SKILL.md
@@ -6,7 +6,6 @@ description: |
   bodies must be written with HTML tags and escaped entities — not plain text or
   \n. Use whenever building or updating a TestLink test case or suite, and as the
   markup reference for testlink-sync.
-disable-model-invocation: true
 ---
 
 # testlink-format

--- a/.claude/skills/testlink-review/SKILL.md
+++ b/.claude/skills/testlink-review/SKILL.md
@@ -6,15 +6,6 @@ description: |
   document is faithfully represented. Use after testlink-sync or any manual
   create/update in TestLink, before calling the work done. The review gate paired
   with testlink-sync.
-disable-model-invocation: true
-tools:
-  - testlink-mcp:list_projects
-  - testlink-mcp:list_test_suites
-  - testlink-mcp:list_test_cases_in_suite
-  - testlink-mcp:read_test_case
-  - testlink-mcp:get_test_cases_for_test_plan
-  - testlink-mcp:list_requirements
-  - testlink-mcp:list_builds
 ---
 
 # testlink-review

--- a/.claude/skills/testlink-sync/SKILL.md
+++ b/.claude/skills/testlink-sync/SKILL.md
@@ -6,24 +6,6 @@ description: |
   requirements, test suites, test plans, builds, and test cases. Use when a QA
   engineer wants to import, sync, upload, or push content into TestLink from a
   document. Pairs with testlink-review (verify) and testlink-format (markup).
-disable-model-invocation: true
-tools:
-  - testlink-mcp:list_projects
-  - testlink-mcp:list_test_suites
-  - testlink-mcp:create_test_suite
-  - testlink-mcp:update_test_suite
-  - testlink-mcp:list_test_cases_in_suite
-  - testlink-mcp:create_test_case
-  - testlink-mcp:update_test_case
-  - testlink-mcp:read_test_case
-  - testlink-mcp:list_requirements
-  - testlink-mcp:create_requirement
-  - testlink-mcp:create_requirement_specification
-  - testlink-mcp:assign_requirements
-  - testlink-mcp:create_test_plan
-  - testlink-mcp:add_test_case_to_test_plan
-  - testlink-mcp:get_test_cases_for_test_plan
-  - testlink-mcp:create_build
 ---
 
 # testlink-sync

--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ execution that *records* a result.
 | **Requirements** (7) | `create_requirement_specification`, `delete_requirement_specification`, `list_requirement_specifications`, `create_requirement`, `get_requirement`, `list_requirements`, `assign_requirements` |
 | **Projects** (1) | `list_projects` |
 
+## Reusable skills
+
+On top of the raw tools, the repo ships three **Claude skills** — packaged workflows your
+assistant invokes when you ask:
+
+| Skill | What it does |
+|-------|--------------|
+| **`testlink-sync`** | Turns a source document — a spec, a GitHub issue, a folder of markdown test cases — into TestLink content: requirements, suites, cases, plans, builds. |
+| **`testlink-review`** | Reads the written content back and verifies it met your goal — the right entities exist, fields are correct and well-formed. |
+| **`testlink-format`** | The HTML markup reference for TestLink's rich-text fields, used by the other two. |
+
+**To use them:** copy the skill folders from [`.claude/skills/`](.claude/skills/) into your
+project's `.claude/skills/` (or `~/.claude/skills/` for every project), then just ask —
+*"Sync the test cases in docs/tests/ into TestLink, then review them."*
+
 ## Configuration
 
 | Variable | Required | Description |


### PR DESCRIPTION
## Summary
- **Skills are now portable & invocable** — removed `disable-model-invocation: true` (all three `testlink-*` skills) and the `testlink-mcp:` tool allowlist (`testlink-review`, `testlink-sync`), so the skills fire for the model and don't break when a user's MCP server is registered under a different name.
- **README "Reusable skills" section** — tells users to copy the three skill folders into their own `.claude/skills/`. Scoped to the skills only (not the repo-internal commands/rules). Passed phrasing + typography review.
- **New `testlink-authoring` rule** — binds the triad (`testlink-sync` producer ↔ `testlink-review` gate, `testlink-format` shared markup), auto-loading when any of the three skill files are edited. Same producer→review convention as `dev-workflow`/`qa-workflow`; passed `reviewing-artifacts`.

No issue backs this branch (raw request), so no `Fixes #N`.

## Test plan
- [ ] The three `testlink-*` skills appear as model-invocable (no `disable-model-invocation`)
- [ ] README "Reusable skills" section renders cleanly and is scoped to skills only
- [ ] `testlink-authoring.md` `paths:` globs match the three skill dirs

Generated with [Claude Code](https://claude.com/claude-code)