### PR TITLE
fix(tests): blank the API key in TC-S1-002 instead of unsetting it

### DIFF
--- a/cicd/tests/testcases/s1-build-deploy/TC-S1-002.yml
+++ b/cicd/tests/testcases/s1-build-deploy/TC-S1-002.yml
@@ -9,13 +9,20 @@ dependencies:
 
 steps:
   - name: Verify server self-exits (exit 1) when API key missing
-    # Must unset TESTLINK_API_KEY — the suite exports it, so without `env -u` the
+    # Must blank TESTLINK_API_KEY — the suite exports it, so without this the
     # server starts and hangs on stdin until `timeout` kills it (exit 124), which
     # would falsely "pass". The server's guard is `process.exit(1)`, so require
     # exactly 1: that rejects a timeout kill (124) and a missing-node error (127),
     # pinning the documented missing-key contract (#90). dist validity is covered
     # by TC-S1-001 (build) + the next step's `node --check`.
-    command: "env -u TESTLINK_API_KEY timeout 5 node dist/index.js; test $? -eq 1 && echo 'EXIT_OK: server self-exited (code 1) without API key'"
+    #
+    # Empty-and-set, NOT `env -u`: the server calls dotenv.config(), which reads
+    # a .env from the cwd (the repo root) and refills any key that is *absent* —
+    # so `env -u` was silently undone by a developer's local .env and the server
+    # started normally. dotenv skips keys already present, so an empty value
+    # survives, and the guard is `if (!TESTLINK_API_KEY)` — empty and absent take
+    # the same branch. This breaks again if dotenv.config() ever gets override:true.
+    command: "TESTLINK_API_KEY= timeout 5 node dist/index.js; test $? -eq 1 && echo 'EXIT_OK: server self-exited (code 1) without API key'"
     expectPatterns:
       - "EXIT_OK"
 

--- a/docs/tests/STORY-001/TS-01-build-deploy.md
+++ b/docs/tests/STORY-001/TS-01-build-deploy.md
@@ -33,7 +33,7 @@ that touch no TestLink data, so they run first and gate everything downstream.
 
 | # | Action | Expected Result |
 |---|--------|-----------------|
-| 1 | Start the server with `TESTLINK_API_KEY` unset, and assert the exit code is exactly 1 | `EXIT_OK` — the server self-exited via its own guard, not a timeout kill (124) or a missing-node error (127) |
+| 1 | Start the server with `TESTLINK_API_KEY` blank, and assert the exit code is exactly 1 | `EXIT_OK` — the server self-exited via its own guard, not a timeout kill (124) or a missing-node error (127) |
 | 2 | Syntax-check the entry point (`node --check dist/index.js`) | `MODULE_OK` |
 
 ### TC-03: Docker image build


### PR DESCRIPTION
## Summary

- `TC-S1-002` asserts the server's missing-key guard by stripping `TESTLINK_API_KEY` with `env -u`. But the server calls `dotenv.config()`, which reads a `.env` from the cwd — the repo root — and refills any key that is **absent**. A developer's local `.env` silently undid the sabotage: the server started, took stdin EOF, exited 0, and the step failed.
- Switched to `TESTLINK_API_KEY=` (empty and set). dotenv skips keys already present in `process.env`, so the empty value survives, and the guard is `if (!TESTLINK_API_KEY)` — empty and absent take the same branch, leaving the #90 contract covered.
- Comment added recording why it is not `env -u`, and that `override: true` on `dotenv.config()` would break it again. Bound test-design doc updated from "unset" to "blank".

## Test plan

- [x] Full suite **19/19** with a repo-root `.env` present — the previously failing condition
- [x] `s1-build-deploy` green with `.env` absent and credentials exported, which is how CI supplies them (`test-suite.yml` `env:` block)
- [x] `npm run audit-bind` — `TS-01` TC-02 still bound, 2 steps to 2 steps
- [ ] Human review

## Why this was invisible until now

`.env` is gitignored, so CI has never had one and has always passed. It surfaced locally because `58ddd16` documented the `cp .env.example .env` workflow — which made **following the documented setup** the thing that broke the test. Any developer who set the repo up as instructed saw 18/19 and a failure that looked like their own change.

## Notes

- This PR closes no issue — none was passed and none is inferable from the branch name. The branch therefore does not follow the profile's `issue-<N>-<slug>` pattern.
- The underlying wart is left alone: a stdio MCP server resolving `.env` from `process.cwd()` means config depends on where the client happened to launch it. Harmless in Docker, and the README documents the local behaviour deliberately — so the fix belongs in the test, not in `dotenv.config()`.

Generated with [Claude Code](https://claude.com/claude-code)