### PR TITLE
Release 1.6.0 — publish the Test Project tools

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -593,7 +593,7 @@ const server = new Server({
     // Keep in step with package.json — `npm version` does not touch this, so a
     // release that bumps only package.json makes the server announce a stale
     // version in its MCP handshake.
-    version: '1.5.0',
+    version: '1.6.0',
 }, {
     capabilities: {
         tools: {},

--- a/docs/releases/v1.6.0.md
+++ b/docs/releases/v1.6.0.md
@@ -1,0 +1,114 @@
+# TestLink MCP Server Release Notes
+## Version 1.6.0 — Test Projects, end to end
+
+### Overview
+
+The root of the TestLink hierarchy was the one thing you had to leave the conversation to
+manage. **Three new tools close that gap** — `create_project`, `update_project` and
+`delete_project` — so "set up a project for the new release and add these suites" can be
+answered end to end.
+
+**No breaking changes.** All 27 existing tools keep their names, arguments, and behaviour.
+The server now exposes **30 tools**.
+
+---
+
+### ✨ `create_project` — start a testing effort from chat
+
+Creates a Test Project and returns its internal ID, ready to hand straight to the suite,
+plan and case tools.
+
+- **Required:** `name` and `prefix`. The Test Case Prefix is stamped into every Test Case
+  external ID (`PREFIX-123`) and is fixed at creation.
+- **Optional:** `notes`, `active`, `is_public`, and the four feature flags —
+  `requirements_enabled`, `test_priority_enabled`, `automation_enabled`,
+  `inventory_enabled`.
+
+### ✏️ `update_project` — partial by construction
+
+Rename a project, correct its notes, deactivate it, change its visibility, recolour it in
+the TestLink UI, or turn a feature on partway through.
+
+**Only the fields you send change.** Every field you omit keeps its current value, so a
+rename never blanks your notes — and an agent should not send a full object defensively.
+
+- Identify the project by **either** its internal ID **or** its Test Case Prefix.
+- **Accepted fields:** `name`, `notes`, `active`, `is_public`, `color`, and the same four
+  feature flags `create_project` takes.
+- The Test Case Prefix itself **cannot** be changed and is absent from the schema — the
+  published identity of existing Test Cases cannot be restated by accident.
+- The feature flags are four named booleans rather than a free-form structure, so a key
+  the server would refuse cannot be invented.
+
+### 🗑️ `delete_project` — behind a confirmation interlock
+
+Deleting a Test Project **cascades to everything beneath it** — every Test Suite, Test
+Case, Test Plan, Build, Execution and Requirement — and there is no parent to restore
+from.
+
+So this tool alone requires `confirm_prefix`, which must exactly equal the target's Test
+Case Prefix. **A mismatch aborts and deletes nothing.** Restating the prefix costs an
+honest caller nothing; it stops one ambiguous sentence from destroying the wrong project.
+
+Like update, delete accepts either the internal ID or the prefix as identity.
+
+---
+
+### ⚠️ TestLink server requirements
+
+| Tool | Backing method | Works against stock TestLink 1.9.20 |
+|------|----------------|-------------------------------------|
+| `create_project` | `tl.createTestProject` | **Yes** |
+| `delete_project` | `tl.deleteTestProject` | **Yes** |
+| `update_project` | `tl.updateTestProject` | **No** — see below |
+
+**`update_project` is the one exception.** `tl.updateTestProject` is not part of upstream
+TestLink's XML-RPC API; it is available in the
+[`dogkeeper886/testlink-code`](https://github.com/dogkeeper886/testlink-code) fork on the
+`main` branch. The requirement is a **capability, not a version** — any TestLink whose
+XML-RPC API exposes that method will do.
+
+Call it against a server that lacks the method and the tool says so by name, pointing at
+the fork and the README, instead of surfacing a raw XML-RPC fault. That explanation is
+attached to the fork-method dispatcher rather than to this tool, so any future fork-gated
+method inherits it.
+
+`create_project` and `delete_project` need nothing beyond a stock TestLink 1.9.20 with the
+XML-RPC API enabled.
+
+### 🧪 Testing
+
+- The integration flow now **provisions its Test Project through `create_project`**,
+  retiring the out-of-band script whose only reason to exist was the missing tool. The
+  tool is exercised on every run.
+- A new stage, **s8 project lifecycle**, covers `update_project` and `delete_project`
+  against a **throwaway** Test Project of its own — partial updates by internal ID and by
+  prefix, the interlock refusing a mismatched confirmation, then delete by both identity
+  forms. The shared fixture every other stage threads is never at risk.
+- The full suite is now **25 tests** and requires an instance providing
+  `tl.updateTestProject` for s8; every other stage runs against stock TestLink.
+
+**Knowingly not covered:** the unsupported-method error mapping. Asserting it needs a
+TestLink that *lacks* the method, and the instance available has it.
+
+### 🧹 Removed
+
+- `npm --prefix cicd/tests run drift` — the story-drift check v1.5.0 introduced. It went
+  with the workflow tooling this repo no longer owns. `audit-bind` and `port-yaml` remain.
+
+---
+
+### Upgrading
+
+```bash
+docker pull dogkeeper886/testlink-mcp:1.6.0
+```
+
+No configuration changes. `TESTLINK_URL` and `TESTLINK_API_KEY` work exactly as before.
+
+### Known issues
+
+- Node names longer than 100 characters fail with a cryptic `Unknown XML-RPC tag 'PRE'`
+  rather than a clear validation error ([#111](https://github.com/dogkeeper886/testlink-mcp/issues/111)).
+- `list_test_suites` on an empty project raises `[7008] ... is empty` instead of returning
+  an empty list ([#111](https://github.com/dogkeeper886/testlink-mcp/issues/111)).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "testlink-mcp-server",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "testlink-mcp-server",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "axios": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testlink-mcp-server",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "MCP server for TestLink test case management",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -680,7 +680,7 @@ const server = new Server(
     // Keep in step with package.json — `npm version` does not touch this, so a
     // release that bumps only package.json makes the server announce a stale
     // version in its MCP handshake.
-    version: '1.5.0',
+    version: '1.6.0',
   },
   {
     capabilities: {


### PR DESCRIPTION
## Summary

- Bumps **both** declared version sites to `1.6.0` — `package.json` and the version the server announces in its MCP handshake (`src/index.ts`). The source comment warns about exactly this: `npm version` touches only the first, and a half-bumped release announces a stale version.
- Adds `docs/releases/v1.6.0.md` covering the three Test Project tools, with the capability requirement stated where it actually applies — `update_project` alone needs a TestLink providing `tl.updateTestProject`; `create_project` and `delete_project` work against stock TestLink 1.9.20.
- Rebuilds `dist/` (version line only) and syncs `package-lock.json`.

Fixes #118

## Test plan

- [x] `npx tsc --noEmit` — root and `cicd/tests`, both clean
- [x] `npm run build` reproduces the committed `dist/` byte-for-byte; tree clean after
- [x] Full integration suite against a TestLink with the fork capability — **25/25 passed**, s8 project lifecycle included
- [x] Tool count reconciles: the built server exposes **30**; README (30), DOCKERHUB (sections sum to 30) and the architecture diagram (30) all agree
- [ ] **Tag after merge** — `v1.5.0` sits on its merge commit and `docker-publish.yml` derives the image tag from it via `type=semver`. Tagging a branch commit would break that.

### Known, not fixed here

- The six `s8-project-lifecycle` cases have no bound test doc under `docs/tests/`. `audit-bind` reports "19 case(s), 0 unbound" against a suite of 25 — it walks docs, so they are invisible to it. Arrived with #116/#117, not this change.
- `DOCKERHUB.md` still advertises "16 Agent-Friendly Commands" (dropped in `12d7817`) and its Image Tags table stops at `v1.2`.

Generated with [Claude Code](https://claude.com/claude-code)